### PR TITLE
Improve bot initialization and reliability

### DIFF
--- a/main.cjs
+++ b/main.cjs
@@ -16,7 +16,7 @@ const {
     usageStats,
     resetProfileCookies,
     backupDatabase
-} = require('./util.cjs');
+} = require('./src/util.cjs');
 
 require('dotenv').config();
 const readline = require('readline');

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "author": "Your Name",
   "license": "ISC",
-  "type": "module",
+  "type": "commonjs",
   "dependencies": {
     "colors": "^1.4.0",
     "dotenv": "^16.3.1",


### PR DESCRIPTION
## Summary
- update the CLI entrypoint to pull helpers from the src tree and keep the package on CommonJS semantics
- make the database wrapper self-initializing, persist shared secrets, and expose helpers for refreshing cookies and backups
- harden the Steam automation utilities to parse stored cookies, surface manual verification states, and reuse the database helpers during auth flows

## Testing
- REP4REP_KEY=dummy node -e "const db=require('./src/db.cjs'); db.init().then(()=>{console.log('db init'); process.exit(0);}).catch(err=>{console.error(err); process.exit(1);});"

------
https://chatgpt.com/codex/tasks/task_e_68ca72833430832581cdaf83484be696