### PR TITLE
Refatorar utilidades e painel com controle de créditos

### DIFF
--- a/src/util.cjs
+++ b/src/util.cjs
@@ -1,12 +1,5 @@
 const fs = require('fs');
 const path = require('path');
-const db = require('./db.cjs');
-const apiModule = require('./api.cjs');
-const api = apiModule;
-const { ApiError } = apiModule;
-const steamBot = require('./steamBot.cjs');
-const { table } = require('table');
-const ReadLine = require('readline');
 const moment = require('moment');
 const { table } = require('table');
 const readline = require('readline');
@@ -14,42 +7,27 @@ const readline = require('readline');
 require('dotenv').config();
 
 const db = require('./db.cjs');
-const apiModule = require('./api.cjs');
-const api = apiModule;
-const { ApiError } = apiModule;
+const api = require('./api.cjs');
+const { ApiError } = require('./api.cjs');
 const createSteamBot = require('./steamBot.cjs');
 
 const ROOT_DIR = path.join(__dirname, '..');
+const DATA_DIR = path.join(ROOT_DIR, 'data');
 const ACCOUNTS_PATH = path.join(ROOT_DIR, 'accounts.txt');
 const LOGS_DIR = path.join(ROOT_DIR, 'logs');
 const BACKUPS_DIR = path.join(ROOT_DIR, 'backups');
+const EXPORTS_DIR = path.join(DATA_DIR, 'exports');
 
-const DEFAULT_LOGIN_DELAY = 30000;
-const DEFAULT_COMMENT_DELAY = 15000;
+const DEFAULT_LOGIN_DELAY = 30_000;
+const DEFAULT_COMMENT_DELAY = 15_000;
 const MAX_COMMENTS_PER_RUN = sanitizePositiveInteger(
   process.env.MAX_COMMENTS_PER_RUN ??
     process.env.COMMENT_LIMIT ??
     process.env.MAX_COMMENTS,
-  10
+  10,
 );
 
 let rl = null;
-const ROOT_DIR = path.join(__dirname, '..');
-const ACCOUNTS_PATH = path.join(ROOT_DIR, 'accounts.txt');
-const LOGS_DIR = path.join(ROOT_DIR, 'logs');
-
-
-let rl = null;
-
-function getReadline() {
-    if (!rl) {
-        rl = ReadLine.createInterface({
-            input: process.stdin,
-            output: process.stdout
-        });
-    }
-    return rl;
-}
 
 const statusMessage = {
   inactive: 0,
@@ -60,6 +38,12 @@ const statusMessage = {
   throttled: 5,
 };
 
+function ensureDirectory(dir) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
 function sanitizeDelay(value, fallback) {
   const num = Number(value);
   return Number.isFinite(num) && num > 0 ? num : fallback;
@@ -68,29 +52,6 @@ function sanitizeDelay(value, fallback) {
 function sanitizePositiveInteger(value, fallback) {
   const num = Number(value);
   return Number.isFinite(num) && num > 0 ? Math.floor(num) : fallback;
-}
-
-function ensureDirectory(dir) {
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
-}
-
-function getReadline() {
-  if (!rl) {
-    rl = readline.createInterface({
-      input: process.stdin,
-      output: process.stdout,
-    });
-  }
-  return rl;
-}
-
-function closeReadline() {
-  if (rl) {
-    rl.close();
-    rl = null;
-  }
 }
 
 function log(message, emptyLine = false) {
@@ -119,10 +80,14 @@ function logInvalidAccount(username, reason) {
 }
 
 function removeFromAccountsFile(username) {
-  if (!fs.existsSync(ACCOUNTS_PATH)) return;
-  const lines = fs.readFileSync(ACCOUNTS_PATH, 'utf-8').split(/\r?\n/);
-  const filtered = lines.filter((line) => line && !line.startsWith(`${username}:`));
-  fs.writeFileSync(ACCOUNTS_PATH, filtered.join('\n'));
+  if (!fs.existsSync(ACCOUNTS_PATH)) {
+    return;
+  }
+
+  const lines = fs.readFileSync(ACCOUNTS_PATH, 'utf8').split(/\r?\n/).filter(Boolean);
+  const filtered = lines.filter((line) => !line.startsWith(`${username}:`));
+  const output = filtered.join('\n');
+  fs.writeFileSync(ACCOUNTS_PATH, output ? `${output}\n` : '');
 }
 
 function readAccountsFile({ silent = false } = {}) {
@@ -134,10 +99,35 @@ function readAccountsFile({ silent = false } = {}) {
   }
 
   return fs
-    .readFileSync(ACCOUNTS_PATH, 'utf-8')
+    .readFileSync(ACCOUNTS_PATH, 'utf8')
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean);
+}
+
+function parseAccountLine(line) {
+  const [username, password, sharedSecret] = line.split(':');
+  if (!username || !password || !sharedSecret) {
+    throw new Error(`Formato inválido de conta: ${line}`);
+  }
+  return { username, password, sharedSecret };
+}
+
+function getReadline() {
+  if (!rl) {
+    rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+  }
+  return rl;
+}
+
+function closeReadline() {
+  if (rl) {
+    rl.close();
+    rl = null;
+  }
 }
 
 function describeApiError(error) {
@@ -161,288 +151,39 @@ function parseStoredCookies(rawCookies, username) {
       return Array.isArray(parsed) ? parsed : [];
     } catch (error) {
       if (username) {
-        log(`[${username}] Falha ao ler cookies salvos. Ignorando.`);
+        log(`[${username}] Falha ao interpretar cookies salvos. Ignorando.`);
       }
       return [];
-    const date = new Date().toISOString().split('T')[0];
-    const logFile = path.join(LOGS_DIR, `${date}.log`);
-    if (!fs.existsSync(LOGS_DIR)) fs.mkdirSync(LOGS_DIR, { recursive: true });
-    const timestamp = new Date().toLocaleTimeString();
-    const line = `[${timestamp}] ${username} - Success: ${success} | Fail: ${fail}\n`;
-    fs.appendFileSync(logFile, line);
-}
-
-function logInvalidAccount(username, reason) {
-    const date = new Date().toISOString().split('T')[0];
-    const logFile = path.join(LOGS_DIR, `invalid-${date}.log`);
-    if (!fs.existsSync(LOGS_DIR)) fs.mkdirSync(LOGS_DIR, { recursive: true });
-    const timestamp = new Date().toLocaleTimeString();
-    const line = `[${timestamp}] ${username} - ${reason}\n`;
-    fs.appendFileSync(logFile, line);
-}
-
-function removeFromAccountsFile(username) {
-    if (!fs.existsSync(ACCOUNTS_PATH)) {
-        return;
-    }
-    const lines = fs.readFileSync(ACCOUNTS_PATH, 'utf-8').split(/\r?\n/);
-    const filtered = lines.filter(line => line && !line.startsWith(`${username}:`));
-    const output = filtered.join('\n');
-    fs.writeFileSync(ACCOUNTS_PATH, output ? `${output}\n` : '');
-}
-
-function readAccountsFile({ silent = false } = {}) {
-    if (!fs.existsSync(ACCOUNTS_PATH)) {
-        if (!silent) {
-            log(`Arquivo accounts.txt não encontrado em ${ACCOUNTS_PATH}.`, true);
-        }
-        return [];
-    }
-
-    const content = fs.readFileSync(ACCOUNTS_PATH, 'utf-8');
-    return content
-        .split(/\r?\n/)
-        .map(line => line.trim())
-        .filter(Boolean);
-}
-
-function describeApiError(error) {
-    if (error instanceof ApiError) {
-        const detail = error.payload?.message || error.payload?.error;
-        const suffix = detail && detail !== error.message ? ` (${detail})` : '';
-        const status = error.status ? ` [status ${error.status}]` : '';
-        return `${error.message}${suffix}${status}`;
-    }
-    return error?.message || String(error);
-}
-
-function parseStoredCookies(rawCookies, username) {
-    if (!rawCookies) {
-        return [];
-    }
-
-    if (typeof rawCookies === 'string') {
-        try {
-            const parsed = JSON.parse(rawCookies);
-            return Array.isArray(parsed) ? parsed : [];
-        } catch (error) {
-            if (username) {
-                log(`[${username}] Failed to parse stored cookies. Ignorando cookies salvos.`);
-            }
-            return [];
-        }
-    }
-
-    return Array.isArray(rawCookies) ? rawCookies : [];
-
-    const filePath = path.join(__dirname, '..', 'accounts.txt');
-    if (!fs.existsSync(filePath)) {
-        return;
-    }
-    const lines = fs.readFileSync(filePath, 'utf-8').split('\n');
-    const filtered = lines.filter(line => !line.startsWith(username + ':'));
-    fs.writeFileSync(filePath, filtered.join('\n'));
-
-}
-
-function parseStoredCookies(rawCookies, username) {
-    if (!rawCookies) {
-        return [];
-    }
-
-    if (typeof rawCookies === 'string') {
-        try {
-            const parsed = JSON.parse(rawCookies);
-            return Array.isArray(parsed) ? parsed : [];
-        } catch (error) {
-            if (username) {
-                log(`[${username}] Failed to parse stored cookies. Ignorando cookies salvos.`);
-            }
-            return [];
-        }
-    }
-
-    return Array.isArray(rawCookies) ? rawCookies : [];
-}
-
-async function autoRun() {
-    const accounts = readAccountsFile();
-    if (accounts.length === 0) {
-        log('Nenhuma conta configurada no accounts.txt. Adicione contas antes de executar o autoRun.', true);
-        return;
-    }
-
-    let profiles;
-    try {
-        profiles = await db.getAllProfiles();
-    } catch (error) {
-        log(`❌ Falha ao carregar perfis do banco de dados: ${error.message}`, true);
-        return;
-    }
-
-    let r4rProfiles;
-    try {
-        r4rProfiles = await api.getSteamProfiles();
-    } catch (error) {
-        log(`[API] Não foi possível obter os perfis do Rep4Rep: ${describeApiError(error)}`, true);
-        return;
-    }
-
-    if (!Array.isArray(r4rProfiles) || r4rProfiles.length === 0) {
-        log('[API] Nenhum perfil Rep4Rep encontrado. Execute a sincronização (--auth-profiles) antes do autoRun.', true);
-        return;
-    }
-
-    for (const [i, account] of accounts.entries()) {
-        const [username, password, sharedSecret] = account.split(':');
-        if (!username || !password || !sharedSecret) {
-            log(`Formato inválido de conta: ${account}`);
-            continue;
-        }
-
-        log(`Attempting to leave comments from: ${username}`);
-
-        const profile = profiles.find(p => p.username === username);
-        if (!profile) {
-            log(`Perfil não encontrado no banco de dados para o usuário: ${username}`);
-            continue;
-        }
-
-        const hoursSinceLastComment = profile.lastComment
-            ? moment().diff(moment(profile.lastComment), 'hours')
-            : Infinity;
-
-        if (!profile.lastComment || hoursSinceLastComment >= 24) {
-            const r4rSteamProfile = r4rProfiles.find(r4rProfile => r4rProfile?.steamId == profile.steamId);
-            if (!r4rSteamProfile) {
-                log(`[${username}] steamProfile não existe no Rep4Rep.`);
-                log('Sincronize os perfis com --auth-profiles e tente novamente.', true);
-                continue;
-            }
-
-            let tasks;
-            try {
-                tasks = await api.getTasks(r4rSteamProfile.id);
-            } catch (error) {
-                log(`[${username}] Falha ao obter tarefas: ${describeApiError(error)}`, true);
-                continue;
-            }
-
-            if (!Array.isArray(tasks) || tasks.length === 0) {
-                log(`[${username}] Nenhuma tarefa disponível. Pulando...`, true);
-                continue;
-            }
-
-            const client = steamBot();
-            let loggedIn = false;
-            try {
-                loggedIn = await loginWithRetries(client, username, password, sharedSecret, profile.cookies);
-            } catch (error) {
-                log(`[${username}] Falha ao autenticar: ${error.message}`, true);
-                continue;
-            }
-
-            if (!loggedIn || (client.status !== statusMessage.loggedIn && !await client.isLoggedIn())) {
-                log(`[${username}] não está logado. Reautenticação necessária.`, true);
-                continue;
-            }
-
-            await autoRunComments(profile, client, tasks, r4rSteamProfile.id, 10);
-            if (i !== accounts.length - 1) {
-                await sleep(process.env.LOGIN_DELAY);
-            }
-        } else {
-            const remaining = Math.max(0, Math.round(24 - hoursSinceLastComment));
-            log(`[${username}] ainda está em cooldown.`);
-            log(`[${username}] tente novamente em: ${remaining} horas`, true);
-        }
     }
   }
 
   return Array.isArray(rawCookies) ? rawCookies : [];
 }
 
-async function sleep(millis, { announce = false } = {}) {
+async function sleep(millis) {
   const ms = Number(millis) || 0;
-  if (ms <= 0) return;
-  if (announce) {
-    const sec = Math.round(ms / 1000);
-    log(`[ pausa de ${sec}s ]`);
+  if (ms <= 0) {
+    return;
   }
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function parseAccountLine(line) {
-  const [username, password, sharedSecret] = line.split(':');
-  if (!username || !password || !sharedSecret) {
-    throw new Error(`Formato inválido de conta: ${line}`);
-  }
-  return { username, password, sharedSecret };
-}
-
-async function removeFromRep4Rep(steamId) {
-  if (!steamId) return { removed: false };
-  try {
-    await api.removeSteamProfile(steamId);
-    log(`[Rep4Rep] Removido steamId: ${steamId}`);
-    return { removed: true };
-  } catch (error) {
-    if (error instanceof ApiError && (error.status === 404 || /não encontrado/i.test(error.message))) {
-      return { removed: false };
-    }
-    log(`[Rep4Rep] Falha ao remover ${steamId}: ${describeApiError(error)}`);
-    return { removed: false, error };
-  }
-}
-
 async function loginWithRetries(client, profileOrUsername, password, sharedSecret, cookies, options = {}) {
-  const { maxRetries = 3, waitOnThrottle = 30000 } = options;
+  const { maxRetries = 3, waitOnThrottle = 30_000 } = options;
 
   let username;
   let pass;
   let secret;
   let storedCookies;
 
-  if (profileOrUsername && typeof profileOrUsername === 'object') {
+  if (profileOrUsername && typeof profileOrUsername === 'object' && !Array.isArray(profileOrUsername)) {
     ({ username, password: pass, sharedSecret: secret, cookies: storedCookies } = profileOrUsername);
-    if (password || sharedSecret || cookies) {
-      log('loginWithRetries recebeu objeto de perfil e parâmetros extras. Ignorando parâmetros adicionais.');
-        log(`[${profile.username}] posting comment:`);
-        log(`${task.requiredCommentText} > ${task.targetSteamProfileName}`, true);
-
-        let commentSent = false;
-        try {
-            await client.postComment(task.targetSteamProfileId, task.requiredCommentText);
-            commentSent = true;
-        } catch (err) {
-            log(`[${profile.username}] failed to post comment: ${err.message}`);
-            log(`Debug Info: TargetSteamProfileId: ${task.targetSteamProfileId}, RequiredCommentText: ${task.requiredCommentText}`);
-            consecutiveFailures++;
-        }
-
-        if (!commentSent) {
-            await sleep(process.env.COMMENT_DELAY);
-            continue;
-        }
-
-        completedTasks.add(task.taskId);
-        commentsPosted++;
-        consecutiveFailures = 0;
-
-        try {
-            await api.completeTask(task.taskId, task.requiredCommentId, authorSteamProfileId);
-        } catch (error) {
-            log(`[${profile.username}] falha ao confirmar a tarefa na API: ${describeApiError(error)}`);
-        }
-
-        try {
-            await db.updateLastComment(profile.steamId);
-        } catch (error) {
-            log(`[${profile.username}] Falha ao atualizar informações do banco: ${error.message}`);
-        }
-
-        log(`[${profile.username}] comment posted and recorded`, true);
-        await sleep(process.env.COMMENT_DELAY);
+    if (
+      typeof password !== 'undefined' ||
+      typeof sharedSecret !== 'undefined' ||
+      typeof cookies !== 'undefined'
+    ) {
+      log('loginWithRetries recebeu objeto de perfil e parâmetros adicionais. Ignorando extras.');
     }
   } else {
     username = profileOrUsername;
@@ -454,426 +195,240 @@ async function loginWithRetries(client, profileOrUsername, password, sharedSecre
   if (!username || !pass) {
     throw new Error('Credenciais inválidas: username e password são obrigatórios.');
   }
-    while (commentsPosted < maxComments && consecutiveFailures < maxConsecutiveFailures && attempts < maxAttempts) {
-        log(`[${profile.username}] Attempting additional comment ${commentsPosted + 1}/${maxComments}`);
-        let additionalTasks;
-        try {
-            additionalTasks = await api.getTasks(authorSteamProfileId); // Fetch new tasks to ensure updated list
-        } catch (error) {
-            log(`[${profile.username}] Falha ao atualizar lista de tarefas: ${describeApiError(error)}`, true);
-            break;
-        }
-
-        additionalTasks = additionalTasks.filter(t => !completedTasks.has(t.taskId));
 
   const parsedCookies = parseStoredCookies(storedCookies, username);
+  let fatalMessage = null;
   let lastError = null;
-  let fatalError = null;
 
   for (let attempt = 0; attempt < maxRetries; attempt++) {
-    const useCookies = attempt === 0 && parsedCookies.length > 0 ? parsedCookies : null;
-        let postedThisRound = false;
-        for (const randomTask of additionalTasks) {
-            if (!randomTask || !randomTask.requiredCommentText || !randomTask.targetSteamProfileId) {
-                log(`[${profile.username}] Invalid random task for additional comments. Skipping...`, true);
-                continue;
-            }
-
-            const randomComment = randomTask.requiredCommentText;
-            const targetSteamProfileId = randomTask.targetSteamProfileId;
-            try {
-                await client.postComment(targetSteamProfileId, randomComment);
-                postedThisRound = true;
-            } catch (err) {
-                log(`[${profile.username}] failed to post additional comment: ${err.message}`);
-                log(`Debug Info: TargetSteamProfileId: ${targetSteamProfileId}, RandomComment: ${randomComment}`);
-                consecutiveFailures++;
-                await sleep(process.env.COMMENT_DELAY);
-                continue;
-            }
-
-            completedTasks.add(randomTask.taskId);
-            commentsPosted++;
-            consecutiveFailures = 0;
-
-            try {
-                await api.completeTask(randomTask.taskId, randomTask.requiredCommentId, authorSteamProfileId); // Mark additional comments as completed
-            } catch (error) {
-                log(`[${profile.username}] falha ao confirmar tarefa adicional: ${describeApiError(error)}`);
-            }
-
-            try {
-                await db.updateLastComment(profile.steamId);
-            } catch (error) {
-                log(`[${profile.username}] Falha ao atualizar informações do banco: ${error.message}`);
-            }
-
-            log(`[${profile.username}] additional comment posted successfully`, true);
-            await sleep(process.env.COMMENT_DELAY);
-            break; // Exit the for loop to attempt the next comment
-        }
-
-        if (postedThisRound) {
-            attempts = 0;
-        } else {
-            attempts++;
-        }
-    }
-
-    log(`[${profile.username}] done with posting comments. Total comments posted: ${commentsPosted}`, true);
-}
-
-async function loginWithRetries(client, profileOrUsername, password, sharedSecret, cookies, maxRetries = 3) {
-    let username;
-    let pass;
-    let secret;
-    let storedCookies;
-
-    if (profileOrUsername && typeof profileOrUsername === 'object' && !Array.isArray(profileOrUsername)) {
-        ({ username, password: pass, sharedSecret: secret, cookies: storedCookies } = profileOrUsername);
-        if (typeof password !== 'undefined' || typeof sharedSecret !== 'undefined' || typeof cookies !== 'undefined') {
-            // Avoid accidental mixed usage of the API
-            log('loginWithRetries recebeu objeto de perfil e parâmetros adicionais. Ignorando parâmetros extras.');
-        }
-    } else {
-        username = profileOrUsername;
-        pass = password;
-        secret = sharedSecret;
-        storedCookies = cookies;
-    }
-
-    if (!username || !pass) {
-        throw new Error('Credenciais inválidas: username e password são obrigatórios.');
-    }
-
-    const parsedCookies = parseStoredCookies(storedCookies, username);
-    let fatalError = null;
-
-    for (let attempt = 0; attempt < maxRetries; attempt++) {
-        const cookiePayload = attempt === 0 && parsedCookies.length > 0 ? parsedCookies : null;
-
-        try {
-            await client.steamLogin(username, pass, null, secret, null, cookiePayload);
-            const isLoggedIn = client.status === statusMessage.loggedIn || await client.isLoggedIn();
-            if (isLoggedIn) {
-                log(`[${username}] login successful`);
-                return true;
-            }
-
-            if ([
-                statusMessage.steamGuardRequired,
-                statusMessage.steamGuardMobileRequired,
-                statusMessage.captchaRequired
-            ].includes(client.status)) {
-                log(`[${username}] login requires manual verification (status: ${client.status}).`);
-                return false;
-            }
-        } catch (error) {
-            const msg = error.message || '';
-            log(`[${username}] login attempt ${attempt + 1} failed: ${msg}`);
-
-            if (/Invalid|denied|banned|RateLimit|Throttle|too many/i.test(msg)) {
-                fatalError = msg;
-                break;
-            }
-
-            if (error.code === 502) {
-                log(`[${username}] WebAPI error 502. Retrying...`);
-                await sleep(10000);
-            } else if (attempt < maxRetries - 1) {
-                await sleep(5000);
-            } else {
-                throw error;
-            }
-        }
-    }
+    const cookiePayload = attempt === 0 && parsedCookies.length > 0 ? parsedCookies : null;
 
     try {
-      await client.steamLogin(username, pass, null, secret, null, useCookies);
-      const status = client.status;
-      const isLoggedIn = status === statusMessage.loggedIn || (await client.isLoggedIn());
-
-      if (isLoggedIn) {
-        log(`[${username}] login efetuado com sucesso.`);
-        return { success: true, status };
+      await client.steamLogin(username, pass, null, secret, null, cookiePayload);
+      const loggedIn = client.status === statusMessage.loggedIn || (await client.isLoggedIn());
+      if (loggedIn) {
+        log(`[${username}] login bem-sucedido.`);
+        try {
+          const freshCookies = await client.getCookies();
+          if (freshCookies && freshCookies.length) {
+            await db.updateCookies(username, freshCookies);
+          }
+        } catch (cookieError) {
+          log(`[${username}] Não foi possível atualizar cookies: ${cookieError.message}`);
+        }
+        return { success: true, status: client.status };
       }
 
       if (
-        status === statusMessage.steamGuardRequired ||
-        status === statusMessage.steamGuardMobileRequired ||
-        status === statusMessage.captchaRequired
+        [
+          statusMessage.steamGuardRequired,
+          statusMessage.steamGuardMobileRequired,
+          statusMessage.captchaRequired,
+        ].includes(client.status)
       ) {
-        log(`[${username}] login requer verificação manual (status ${status}).`);
-        return { success: false, requiresAction: true, status };
+        log(`[${username}] login requer ação manual (status: ${client.status}).`);
+        return { success: false, requiresAction: true, status: client.status };
       }
 
-      if (status === statusMessage.throttled) {
+      if (client.status === statusMessage.throttled) {
         log(`[${username}] tentativa bloqueada temporariamente. Aguardando para tentar novamente...`);
-        await sleep(waitOnThrottle, { announce: true });
+        await sleep(waitOnThrottle);
         continue;
       }
 
-      lastError = new Error(`Status de login inesperado (${status}).`);
+      lastError = new Error(`Status de login inesperado (${client.status}).`);
     } catch (error) {
-      const message = error?.message || '';
-
-      if (/AccountLoginDeniedThrottle/i.test(message)) {
-        log(`[${username}] login bloqueado temporariamente pelo Steam (${message}).`);
-        await sleep(waitOnThrottle, { announce: true });
-        lastError = error;
-        continue;
-      }
-
-      if (/RateLimit|Throttle|too many|temporarily|timeout/i.test(message)) {
-        log(`[${username}] aguardando devido a limite temporário (${message}).`);
-        await sleep(waitOnThrottle, { announce: true });
-        lastError = error;
-        continue;
-      }
+      lastError = error instanceof Error ? error : new Error(String(error));
+      const message = lastError.message || '';
 
       if (/password|credentials|denied|banned|disabled|vac/i.test(message)) {
-        fatalError = message;
+        fatalMessage = message;
         break;
       }
 
-      lastError = error instanceof Error ? error : new Error(String(error));
+      if (/AccountLoginDeniedThrottle|RateLimit|Throttle|too many|temporarily|timeout/i.test(message)) {
+        log(`[${username}] aguardando devido ao limite temporário (${message}).`);
+        await sleep(waitOnThrottle);
+        continue;
+      }
+
       if (attempt < maxRetries - 1) {
         await sleep(5000);
       }
     }
   }
 
-  if (fatalError) {
-    log(`[${username}] login marcado como inválido: ${fatalError}`);
-    logInvalidAccount(username, fatalError);
-
+  if (fatalMessage) {
+    log(`[${username}] credenciais marcadas como inválidas: ${fatalMessage}`);
+    logInvalidAccount(username, fatalMessage);
     try {
-      const profiles = await db.getAllProfiles();
-      const profile = profiles.find((p) => p.username === username);
-      if (profile?.steamId) {
-        await removeFromRep4Rep(profile.steamId);
-      }
+      await db.removeProfile(username);
     } catch (error) {
-      log(`[${username}] Falha ao localizar perfil para limpeza: ${error.message}`);
-        try {
-            const profile = (await db.getAllProfiles()).find(p => p.username === username);
-            if (profile?.steamId) {
-                await removeFromRep4Rep(profile.steamId);
-            }
-        } catch (err) {
-            log(`[${username}] Falha ao buscar perfil para remoção: ${err.message}`);
-        }
-
-        await db.removeProfile(username);
-        removeFromAccountsFile(username);
-        return false;
+      log(`[${username}] Falha ao remover perfil do banco: ${error.message}`);
     }
-
-    await db.removeProfile(username);
     removeFromAccountsFile(username);
-
-    return { success: false, fatal: true, reason: fatalError };
+    return { success: false, fatal: true, reason: fatalMessage };
   }
 
-  throw lastError || new Error(`[${username}] login falhou após ${maxRetries} tentativas.`);
+  throw lastError || new Error(`[${username}] login falhou após múltiplas tentativas.`);
 }
 
-async function syncWithRep4rep(client) {
-  let steamId = await client.getSteamId();
+async function removeFromRep4Rep(steamId, options = {}) {
   if (!steamId) {
-    return 'Não foi possível obter o SteamID do cliente.';
+    return { removed: false };
   }
 
-  let steamProfiles;
   try {
-    steamProfiles = await api.getSteamProfiles();
+    await api.removeSteamProfile(steamId, { token: options.apiToken });
+    log(`[Rep4Rep] Removido steamId: ${steamId}`);
+    return { removed: true };
   } catch (error) {
-    const message = describeApiError(error);
-    log(`Erro ao obter steamProfiles: ${message}`);
-    return `Erro ao obter steamProfiles: ${message}`;
+    if (error instanceof ApiError && (error.status === 404 || /não encontrado/i.test(error.message))) {
+      return { removed: false };
+    }
+    log(`[Rep4Rep] Falha ao remover ${steamId}: ${describeApiError(error)}`);
+    return { removed: false, error };
+  }
+}
+
+async function showAllProfiles() {
+  const profiles = await db.getAllProfiles();
+  if (!profiles.length) {
+    log('Nenhum perfil cadastrado.');
+    return;
   }
 
-  if (!Array.isArray(steamProfiles)) {
-    return 'Resposta inválida ao obter perfis Rep4Rep.';
+  const rows = [['Usuário', 'SteamID', 'Último comentário', 'Comentários (24h)']];
+  for (const profile of profiles) {
+    const lastComment = profile.lastComment
+      ? moment(profile.lastComment).format('YYYY-MM-DD HH:mm')
+      : 'nunca';
+    const count24h = await db.getCommentsInLast24Hours(profile.steamId);
+    rows.push([profile.username, profile.steamId ?? '-', lastComment, String(count24h)]);
   }
 
-  const exists = steamProfiles.some((steamProfile) => String(steamProfile.steamId) === String(steamId));
+  console.log(table(rows));
+}
 
-  if (!exists) {
+async function addProfilesFromFile(options = {}) {
+  const accounts = readAccountsFile();
+  if (!accounts.length) {
+    log('Nenhuma conta encontrada em accounts.txt.');
+    return { added: 0, total: 0 };
+  }
+
+  const existingProfiles = await db.getAllProfiles();
+  const knownUsers = new Set(existingProfiles.map((profile) => profile.username));
+
+  let added = 0;
+
+  for (const line of accounts) {
+    let account;
     try {
-      const res = await api.addSteamProfile(steamId);
-      if (res?.error) {
-        return res.error;
-      }
+      account = parseAccountLine(line);
     } catch (error) {
-      const message = describeApiError(error);
-      log(`Erro ao adicionar steamProfile: ${message}`);
-      return `Erro ao adicionar steamProfile: ${message}`;
-    }
-  }
-
-  return true;
-}
-
-async function promptForCode(username, client) {
-  switch (client.status) {
-    case statusMessage.steamGuardRequired:
-      log(`[${username}] Código Steam Guard por email necessário (${client.emailDomain || 'email desconhecido'}).`);
-      break;
-    case statusMessage.steamGuardMobileRequired:
-      log(`[${username}] Código do Steam Guard Mobile necessário.`);
-      break;
-    case statusMessage.captchaRequired:
-      log(`[${username}] CAPTCHA necessário. URL: ${client.captchaUrl}`);
-      break;
-    default:
-      log(`[${username}] Código adicional requerido.`);
-  }
-
-  return new Promise((resolve) => {
-    getReadline().question('>> ', (answer) => {
-      resolve(answer.trim());
-    });
-  });
-}
-async function sleep(millis) {
-    const ms = Number(millis) || 0;
-    if (ms <= 0) {
-        return Promise.resolve();
+      log(error.message);
+      continue;
     }
 
-    const sec = Math.round(ms / 1000);
-    log(`[ ${sec}s delay ] ...`, true);
-    return new Promise(resolve => setTimeout(resolve, ms));
-}
+    if (knownUsers.has(account.username)) {
+      log(`[${account.username}] já cadastrado. Pulando.`);
+      continue;
+    }
 
-async function authAllProfiles() {
-    let profiles = await db.getAllProfiles();
-    for (const [i, profile] of profiles.entries()) {
-        log(`Attempting to auth: ${profile.username} (${profile.steamId})`);
-        let client = steamBot();
-        let loggedIn = false;
-        try {
-            loggedIn = await loginWithRetries(client, profile);
-        } catch (error) {
-            log(`[${profile.username}] Falha ao autenticar: ${error.message}`, true);
-            continue;
-        }
-
-        if (!loggedIn) {
-            log(`[${profile.username}] Requer verificação manual. Pulando perfil.`, true);
-            continue;
-        }
-
-async function addProfileSetup(accountName, password, sharedSecret) {
-  const client = createSteamBot();
-
-  const maxAttempts = 5;
-  let attempts = 0;
-  let success = false;
-        try {
-            let res = await syncWithRep4rep(client);
-            if (res === true || res === 'Steam profile already added/exists on rep4rep.') {
-                log(`[${profile.username}] Synced to Rep4Rep`, true);
-            } else {
-                log(`[${profile.username}] Failed to sync:`);
-                log(res, true);
-            }
-        } catch (error) {
-            log(`[${profile.username}] Erro ao sincronizar: ${describeApiError(error)}`, true);
-
-            log(`[${profile.username}] Erro ao sincronizar: ${describeApiError(error)}`, true);
-
-            log(`[${profile.username}] Erro ao sincronizar: ${error.message}`, true);
-
-        }
-
-  while (attempts < maxAttempts && !success) {
-    attempts += 1;
+    const client = createSteamBot();
+    let loginResult;
     try {
-      await client.steamLogin(accountName, password, null, sharedSecret, null);
-      let loggedIn = client.status === statusMessage.loggedIn || (await client.isLoggedIn());
+      loginResult = await loginWithRetries(client, account, null, null, null, options.loginOptions);
+    } catch (error) {
+      log(`[${account.username}] Falha ao autenticar: ${error.message}`);
+      continue;
+    }
 
-      if (!loggedIn) {
-        if (
-          client.status === statusMessage.steamGuardRequired ||
-          client.status === statusMessage.steamGuardMobileRequired ||
-          client.status === statusMessage.captchaRequired
-        ) {
-          const code = await promptForCode(accountName, client);
-          if (!code) {
-            throw new Error('Código obrigatório não fornecido.');
-          }
-          const captcha = client.status === statusMessage.captchaRequired ? code : null;
-          const guardCode = client.status !== statusMessage.captchaRequired ? code : null;
-          await client.steamLogin(accountName, password, guardCode, sharedSecret, captcha);
-          loggedIn = client.status === statusMessage.loggedIn || (await client.isLoggedIn());
-        } else if (client.status === statusMessage.throttled) {
-          log(`[${accountName}] tentativa temporariamente bloqueada. Aguardando antes de tentar novamente.`);
-          await sleep(30000, { announce: true });
-          continue;
-        }
+    if (!loginResult?.success) {
+      if (loginResult?.requiresAction) {
+        log(`[${account.username}] requer verificação manual (Steam Guard/CAPTCHA).`);
       }
+      continue;
+    }
 
-      if (!loggedIn) {
-        throw new Error('Não foi possível autenticar o perfil.');
-      }
-
-      const res = await syncWithRep4rep(client);
-      if (res === true || res === 'Steam profile already added/exists on rep4rep.') {
-        log(`[${accountName}] sincronizado com Rep4Rep`, true);
+    try {
+      const steamId = await client.getSteamId();
+      if (!steamId) {
+        log(`[${account.username}] SteamID não disponível após login.`);
       } else {
-        log(`[${accountName}] falha ao sincronizar: ${res}`, true);
+        try {
+          await api.addSteamProfile(steamId, { token: options.apiToken });
+        } catch (error) {
+          if (!(error instanceof ApiError && error.status === 409)) {
+            throw error;
+          }
+        }
       }
-
-      log(`[${accountName}] Perfil adicionado com sucesso.`);
-      success = true;
+      added += 1;
+      knownUsers.add(account.username);
+      log(`[${account.username}] perfil adicionado com sucesso.`);
     } catch (error) {
-      const message = error?.message || String(error);
-      log(`Erro ao adicionar perfil ${accountName}: ${message}`);
-      if (message.includes('RateLimitExceeded')) {
-        await sleep(60000, { announce: true });
-      } else if (attempts < maxAttempts) {
-        await sleep(5000);
-      }
+      log(`[${account.username}] Falha ao sincronizar com Rep4Rep: ${describeApiError(error)}`);
     }
   }
 
-  if (!success) {
-    log(`Falha ao adicionar perfil ${accountName} após ${maxAttempts} tentativas.`);
-  }
+  log(`Processo concluído. ${added} novo(s) perfil(is) adicionados.`);
+  return { added, total: accounts.length };
 }
 
-async function autoRunComments({ profile, client, tasks, remoteProfileId, maxComments, commentDelay }) {
+async function addProfilesAndRun(options = {}) {
+  await addProfilesFromFile(options);
+  return autoRun(options);
+}
+
+function resolveRemoteProfileId(remoteProfile) {
+  return (
+    remoteProfile?.id ??
+    remoteProfile?.steamProfileId ??
+    remoteProfile?.steamId ??
+    null
+  );
+}
+
+async function runTasksForProfile({
+  profile,
+  client,
+  remoteProfileId,
+  apiClient,
+  apiToken,
+  maxComments,
+  commentDelay,
+  onTaskComplete,
+}) {
   let commentsPosted = 0;
   let consecutiveFailures = 0;
   const maxConsecutiveFailures = 3;
   const completedTasks = new Set();
+  let shouldStop = false;
 
-  const ensureTasks = async () => {
-    if (Array.isArray(tasks) && tasks.length) {
-      return tasks;
-    }
-    const freshTasks = await api.getTasks(remoteProfileId);
-    tasks = Array.isArray(freshTasks) ? freshTasks : [];
-    return tasks;
+  const fetchTasks = async () => {
+    const payload = await apiClient.getTasks(remoteProfileId, { token: apiToken });
+    return Array.isArray(payload) ? payload : [];
   };
 
   while (commentsPosted < maxComments && consecutiveFailures < maxConsecutiveFailures) {
-    const availableTasks = (await ensureTasks()).filter(
-      (task) => task && !completedTasks.has(task.taskId) && task.requiredCommentText && task.targetSteamProfileId
+    const tasks = await fetchTasks();
+    const task = tasks.find(
+      (item) =>
+        item &&
+        !completedTasks.has(item.taskId) &&
+        item.requiredCommentText &&
+        item.targetSteamProfileId,
     );
 
-    if (availableTasks.length === 0) {
-      log(`[${profile.username}] nenhuma tarefa válida disponível no momento.`);
+    if (!task) {
+      log(`[${profile.username}] Nenhuma tarefa disponível no momento.`);
       break;
     }
 
-    const task = availableTasks.shift();
     completedTasks.add(task.taskId);
-
     log(`[${profile.username}] Comentando em ${task.targetSteamProfileName || task.targetSteamProfileId}`);
-    log(task.requiredCommentText);
 
     try {
       await client.postComment(task.targetSteamProfileId, task.requiredCommentText);
@@ -881,15 +436,28 @@ async function autoRunComments({ profile, client, tasks, remoteProfileId, maxCom
       consecutiveFailures = 0;
 
       try {
-        await api.completeTask(task.taskId, task.requiredCommentId, remoteProfileId);
+        await apiClient.completeTask(task.taskId, task.requiredCommentId, remoteProfileId, {
+          token: apiToken,
+        });
       } catch (error) {
-        log(`[${profile.username}] falha ao confirmar tarefa: ${describeApiError(error)}`);
+        log(`[${profile.username}] Falha ao confirmar tarefa: ${describeApiError(error)}`);
       }
 
       try {
         await db.updateLastComment(profile.steamId);
       } catch (error) {
-        log(`[${profile.username}] falha ao atualizar banco: ${error.message}`);
+        log(`[${profile.username}] Falha ao atualizar banco: ${error.message}`);
+      }
+
+      if (typeof onTaskComplete === 'function') {
+        try {
+          const result = await onTaskComplete({ profile, task });
+          if (result === false) {
+            shouldStop = true;
+          }
+        } catch (callbackError) {
+          log(`[${profile.username}] Callback de task falhou: ${callbackError.message}`);
+        }
       }
 
       if (commentsPosted < maxComments) {
@@ -897,25 +465,39 @@ async function autoRunComments({ profile, client, tasks, remoteProfileId, maxCom
       }
     } catch (error) {
       consecutiveFailures += 1;
-      log(`[${profile.username}] falha ao comentar: ${error.message}`);
+      log(`[${profile.username}] Falha ao comentar: ${error.message}`);
       await sleep(commentDelay);
+    }
+
+    if (shouldStop) {
+      break;
     }
   }
 
   if (commentsPosted === 0) {
-    log(`[${profile.username}] nenhum comentário enviado.`);
+    log(`[${profile.username}] Nenhum comentário enviado.`);
   } else {
-    log(`[${profile.username}] total de comentários enviados: ${commentsPosted}`);
+    log(`[${profile.username}] Total de comentários enviados: ${commentsPosted}`);
   }
 
-  return commentsPosted;
+  return { commentsPosted, stoppedEarly: shouldStop };
 }
 
-async function autoRun() {
+async function autoRun(options = {}) {
+  const {
+    apiClient = api,
+    apiToken = null,
+    maxCommentsPerAccount = MAX_COMMENTS_PER_RUN,
+    commentDelay = sanitizeDelay(process.env.COMMENT_DELAY, DEFAULT_COMMENT_DELAY),
+    loginDelay = sanitizeDelay(process.env.LOGIN_DELAY, DEFAULT_LOGIN_DELAY),
+    onTaskComplete,
+    filterProfiles,
+  } = options;
+
   const accounts = readAccountsFile();
   if (!accounts.length) {
     log('Nenhuma conta configurada no accounts.txt. Adicione contas antes de executar o autoRun.', true);
-    return;
+    return { totalComments: 0, perAccount: [] };
   }
 
   let profiles;
@@ -923,28 +505,24 @@ async function autoRun() {
     profiles = await db.getAllProfiles();
   } catch (error) {
     log(`❌ Falha ao carregar perfis do banco de dados: ${error.message}`, true);
-    return;
+    return { totalComments: 0, perAccount: [] };
   }
 
   let remoteProfiles;
   try {
-    remoteProfiles = await api.getSteamProfiles();
+    remoteProfiles = await apiClient.getSteamProfiles({ token: apiToken });
   } catch (error) {
     log(`[API] Não foi possível obter os perfis do Rep4Rep: ${describeApiError(error)}`, true);
-    return;
+    return { totalComments: 0, perAccount: [] };
   }
 
   if (!Array.isArray(remoteProfiles) || remoteProfiles.length === 0) {
-    log('[API] Nenhum perfil Rep4Rep encontrado. Execute a sincronização (--auth-profiles) antes do autoRun.', true);
-    return;
+    log('[API] Nenhum perfil Rep4Rep encontrado. Execute a sincronização antes do autoRun.', true);
+    return { totalComments: 0, perAccount: [] };
   }
 
-  const profileMap = new Map(profiles.map((profile) => [profile.username, profile]));
   const remoteMap = new Map(remoteProfiles.map((remote) => [String(remote.steamId), remote]));
-
-  const loginDelay = sanitizeDelay(process.env.LOGIN_DELAY, DEFAULT_LOGIN_DELAY);
-  const commentDelay = sanitizeDelay(process.env.COMMENT_DELAY, DEFAULT_COMMENT_DELAY);
-  const maxComments = Math.max(1, MAX_COMMENTS_PER_RUN);
+  const summary = { totalComments: 0, perAccount: [] };
 
   for (const [index, accountLine] of accounts.entries()) {
     let account;
@@ -953,585 +531,318 @@ async function autoRun() {
     } catch (error) {
       log(error.message);
       continue;
-        steamProfiles = await api.getSteamProfiles();
-    } catch (error) {
-        const message = describeApiError(error);
-        log(`Error retrieving steamProfiles: ${message}`);
-        return `Error retrieving steamProfiles: ${message}`;
     }
 
-    const { username, password, sharedSecret } = account;
-    log(`Processando ${username} (${index + 1}/${accounts.length})`);
-
-    const profile = profileMap.get(username);
+    const profile = profiles.find((item) => item.username === account.username);
     if (!profile) {
-      log(`Perfil local não encontrado para ${username}. Execute addProfileSetup primeiro.`);
+      log(`[${account.username}] Perfil não encontrado no banco de dados.`);
       continue;
     }
 
-    const remoteProfile = remoteMap.get(String(profile.steamId));
+    if (typeof filterProfiles === 'function' && !filterProfiles(profile)) {
+      log(`[${account.username}] Ignorado pelo filtro.`);
+      continue;
+    }
+
+    const hoursSinceLastComment = profile.lastComment
+      ? moment().diff(moment(profile.lastComment), 'hours', true)
+      : Infinity;
+
+    if (hoursSinceLastComment < 24) {
+      const remaining = Math.max(0, Math.round(24 - hoursSinceLastComment));
+      log(`[${account.username}] ainda está em cooldown. Tente novamente em ${remaining}h.`);
+      continue;
+    }
+
+    let remoteProfile = remoteMap.get(String(profile.steamId));
     if (!remoteProfile) {
-      log(`[${username}] perfil não sincronizado no Rep4Rep.`);
-      log('Sincronize os perfis com --auth-profiles e tente novamente.', true);
-      continue;
-    }
-
-    const hoursSinceLastComment = profile.lastComment ? moment().diff(moment(profile.lastComment), 'hours') : Infinity;
-    if (Number.isFinite(hoursSinceLastComment) && hoursSinceLastComment < 24) {
-      const remaining = Math.max(0, Math.ceil(24 - hoursSinceLastComment));
-      log(`[${username}] ainda em cooldown. Tente novamente em aproximadamente ${remaining}h.`);
-      continue;
-    if (!exists) {
-        let res;
-        try {
-            res = await api.addSteamProfile(steamId);
-        } catch (error) {
-            const message = describeApiError(error);
-            log(`Error adding steamProfile: ${message}`);
-            return `Error adding steamProfile: ${message}`;
+      log(`[${account.username}] perfil não sincronizado com Rep4Rep. Tentando adicionar...`);
+      try {
+        await apiClient.addSteamProfile(profile.steamId, { token: apiToken });
+        remoteProfiles = await apiClient.getSteamProfiles({ token: apiToken });
+        remoteProfile = remoteProfiles.find((item) => String(item.steamId) === String(profile.steamId));
+        if (remoteProfile) {
+          remoteMap.set(String(profile.steamId), remoteProfile);
         }
-        if (res.error) {
-            return res.error;
-        }
-    }
-
-    const client = createSteamBot();
-    let loginResult;
-    try {
-      loginResult = await loginWithRetries(client, username, password, sharedSecret, profile.cookies);
-    } catch (error) {
-      log(`[${username}] falha ao autenticar: ${error.message}`, true);
-      continue;
-    }
-
-    if (!loginResult.success) {
-      if (loginResult.requiresAction) {
-        log(`[${username}] requer verificação manual. Pule para o próximo perfil.`, true);
-      } else if (loginResult.fatal) {
-        log(`[${username}] marcado como inválido. Perfil removido das filas.`, true);
-      } else {
-        log(`[${username}] não conseguiu autenticar automaticamente.`, true);
-      }
-      continue;
-    }
-
-    let tasks;
-    try {
-      tasks = await api.getTasks(remoteProfile.id);
-    } catch (error) {
-      log(`[${username}] falha ao obter tarefas: ${describeApiError(error)}`, true);
-      continue;
-    }
-
-    if (!Array.isArray(tasks) || tasks.length === 0) {
-      log(`[${username}] nenhuma tarefa disponível.`, true);
-      continue;
-    }
-
-    await autoRunComments({
-      profile,
-      client,
-      tasks,
-      remoteProfileId: remoteProfile.id,
-      maxComments,
-      commentDelay,
-    });
-
-    if (index !== accounts.length - 1) {
-      await sleep(loginDelay);
-    }
-  }
-
-  log('autoRun concluído.');
-}
-
-async function showAllProfiles() {
-  const profiles = await db.getAllProfiles();
-  const data = [['steamId', 'username', 'lastComment']];
-  profiles.forEach((profile) => {
-    data.push([profile.steamId, profile.username, profile.lastComment]);
-  });
-  console.log(table(data));
-}
-
-async function authAllProfiles() {
-  const profiles = await db.getAllProfiles();
-  const loginDelay = sanitizeDelay(process.env.LOGIN_DELAY, DEFAULT_LOGIN_DELAY);
-
-  for (const [index, profile] of profiles.entries()) {
-    log(`Autenticando ${profile.username} (${profile.steamId})`);
-    const client = createSteamBot();
-
-    let loginResult;
-    try {
-      loginResult = await loginWithRetries(client, profile);
-    } catch (error) {
-      log(`[${profile.username}] Falha ao autenticar: ${error.message}`, true);
-      continue;
-async function addProfileSetup(accountName, password, sharedSecret) {
-    let client = steamBot();
-
-    let attempts = 0;
-    const maxAttempts = 5;
-    let success = false;
-
-    while (attempts < maxAttempts && !success) {
-        try {
-            await client.steamLogin(accountName, password, null, sharedSecret, null);
-
-            let loggedIn = client.status === statusMessage.loggedIn || await client.isLoggedIn();
-
-            if (!loggedIn) {
-                if (client.status === statusMessage.steamGuardRequired) {
-                    const code = await promptForCode(accountName, client);
-                    if (!code) {
-                        throw new Error('Steam Guard code não informado.');
-                    }
-                    await client.steamLogin(accountName, password, code, sharedSecret, null);
-                    loggedIn = client.status === statusMessage.loggedIn || await client.isLoggedIn();
-                } else if (client.status === statusMessage.captchaRequired) {
-                    const captcha = await promptForCode(accountName, client);
-                    if (!captcha) {
-                        throw new Error('Captcha não informado.');
-                    }
-                    await client.steamLogin(accountName, password, null, sharedSecret, captcha);
-                    loggedIn = client.status === statusMessage.loggedIn || await client.isLoggedIn();
-                } else if (client.status === statusMessage.steamGuardMobileRequired) {
-                    log(`[${accountName}] Aguardando novo código do Steam Guard Mobile...`);
-                    attempts++;
-                    await sleep(30000);
-                    continue;
-                }
-            }
-
-            if (!loggedIn) {
-                throw new Error('Não foi possível autenticar o perfil.');
-            }
-
-            let res = await syncWithRep4rep(client);
-            if (res === true || res === 'Steam profile already added/exists on rep4rep.') {
-                log(`[${accountName}] Synced to Rep4Rep`, true);
-            } else {
-                log(`[${accountName}] Failed to sync:`);
-                log(res, true);
-            }
-
-            log(`[${accountName}] Profile added`);
-            success = true;
-        } catch (error) {
-            attempts++;
-            const errorMessage = error?.message || String(error);
-            if (errorMessage.includes('RateLimitExceeded')) {
-                log(`Rate limit exceeded for ${accountName}. Waiting before retrying...`);
-                await sleep(30000); // wait 1 minute before retrying
-            } else {
-                log(`Error adding profile ${accountName}: ${errorMessage}`);
-                if (attempts < maxAttempts) {
-                    await sleep(5000);
-                }
-            }
-        }
-    }
-
-    if (!loginResult.success) {
-      if (loginResult.requiresAction) {
-        log(`[${profile.username}] requer verificação manual. Pulando.`, true);
-      } else if (loginResult.fatal) {
-        log(`[${profile.username}] credenciais inválidas. Perfil removido.`, true);
-      }
-      continue;
-    }
-
-    log(`[${profile.username}] autenticado.`);
-
-    try {
-      const res = await syncWithRep4rep(client);
-      if (res === true || res === 'Steam profile already added/exists on rep4rep.') {
-        log(`[${profile.username}] sincronizado com Rep4Rep`, true);
-      } else {
-        log(`[${profile.username}] falhou ao sincronizar: ${res}`, true);
-      }
-    } catch (error) {
-      log(`[${profile.username}] erro ao sincronizar: ${describeApiError(error)}`, true);
-    }
-
-    if (index !== profiles.length - 1) {
-      await sleep(loginDelay);
-    }
-  }
-
-  log('authProfiles concluído.');
-function createLoggedError(message) {
-    const error = new Error(message);
-    error.logged = true;
-    return error;
-}
-
-async function removeProfile(username) {
-    const target = typeof username === 'string' ? username.trim() : '';
-
-    if (!target) {
-        const message = 'Informe o usuário a remover.';
-        log(message, true);
-        return { success: false, reason: 'missing-username', message };
-    }
-
-    let profile;
-    try {
-        const profiles = await db.getAllProfiles();
-        profile = profiles.find(p => p.username === target);
-    } catch (error) {
-        const message = `❌ Falha ao carregar perfis: ${error.message}`;
-        log(message, true);
-        throw createLoggedError(message);
-    }
-
-    if (!profile) {
-        const message = `⚠️ Perfil '${target}' não encontrado.`;
-        log(message, true);
-        return { success: false, reason: 'not-found', message };
-    }
-
-    if (profile.steamId) {
-        await removeFromRep4Rep(profile.steamId);
-    }
-
-    try {
-        const result = await db.removeProfile(target);
-        if (!result || result.changes === 0) {
-            log(`⚠️ Nenhuma entrada removida para '${target}'.`, true);
-        }
-    } catch (error) {
-        const message = `❌ Erro ao remover '${target}' do banco: ${error.message}`;
-        log(message, true);
-        throw createLoggedError(message);
-    }
-
-    removeFromAccountsFile(target);
-    const successMessage = `✅ Remoção local concluída para '${target}'.`;
-    log(successMessage, true);
-    return { success: true, message: successMessage };
-}
-
-async function promptForCode(username, client) {
-    switch (client.status) {
-        case 1:
-            log(`[${username}] steamGuard code required  (${client.emailDomain})`);
-            break;
-        case 2:
-            log(`[${username}] steamGuardMobile code required`);
-            break;
-        case 3:
-            log(`[${username}] captcha required`);
-            log(`URL: ${client.captchaUrl}`);
-            break;
-        default:
-            console.log('fatal?');
-            console.log(client.status);
-            process.exit();
-    }
-
-    let res =  await new Promise(resolve => {
-        getReadline().question('>> ', resolve);
-    });
-    return res;
-}
-
-async function removeProfile(username, { skipRemote = false } = {}) {
-  const target = typeof username === 'string' ? username.trim() : '';
-  if (!target) {
-    const message = 'Informe o usuário a remover.';
-    log(message, true);
-    return { success: false, message };
-  }
-
-  let profile;
-  try {
-    const profiles = await db.getAllProfiles();
-    profile = profiles.find((p) => p.username === target);
-  } catch (error) {
-    const message = `❌ Falha ao carregar perfis: ${error.message}`;
-    log(message, true);
-    return { success: false, message };
-  }
-
-  if (!profile) {
-    const message = `⚠️ Perfil '${target}' não encontrado.`;
-    log(message, true);
-    return { success: false, message };
-  }
-
-  let remoteRemoved = false;
-  if (!skipRemote && profile.steamId) {
-    const result = await removeFromRep4Rep(profile.steamId);
-    remoteRemoved = Boolean(result.removed);
-  }
-
-  try {
-    const result = await db.removeProfile(target);
-    if (!result || result.changes === 0) {
-      const message = `⚠️ Nenhuma entrada removida para '${target}'.`;
-      log(message, true);
-      return { success: false, message, remoteRemoved };
-async function addProfilesFromFile() {
-    const accounts = readAccountsFile();
-    const accountCount = accounts.length;
-    if (accountCount === 0) {
-        log('Nenhuma conta encontrada para adicionar.', true);
-        return;
-    }
-
-    log(`Starting to add ${accountCount} profiles from file.`);
-
-    for (const [index, account] of accounts.entries()) {
-        const [username, password, sharedSecret] = account.split(':');
-        log(`Adding profile ${index + 1} of ${accountCount}: ${username}`);
-        
-        try {
-            if (!username || !password || !sharedSecret) {
-                throw new Error(`Invalid account format for ${account}`);
-            }
-            await addProfileSetup(username, password, sharedSecret);
-            log(`Profile ${username} added successfully.`);
-        } catch (error) {
-            log(`Error adding profile ${username}: ${error.message}`);
-        }
-        
-        if (index !== accounts.length - 1) {
-            await sleep(30000); // Add delay to avoid throttling
-        }
-    }
-  } catch (error) {
-    const message = `❌ Erro ao remover '${target}' do banco: ${error.message}`;
-    log(message, true);
-    return { success: false, message, remoteRemoved };
-  }
-
-  removeFromAccountsFile(target);
-  const message = `✅ Remoção local concluída para '${target}'.`;
-  log(message, true);
-  return { success: true, message, remoteRemoved };
-}
-
-async function addProfilesFromFile() {
-  const accounts = readAccountsFile();
-  if (!accounts.length) {
-    log('Nenhuma conta encontrada para adicionar.', true);
-    return;
-  }
-
-  for (const [index, line] of accounts.entries()) {
-    try {
-      const { username, password, sharedSecret } = parseAccountLine(line);
-      log(`Adicionando perfil ${index + 1} de ${accounts.length}: ${username}`);
-      await addProfileSetup(username, password, sharedSecret);
-    } catch (error) {
-      log(`Erro ao adicionar perfil: ${error.message}`);
-    }
-
-    if (index !== accounts.length - 1) {
-      await sleep(30000, { announce: true });
-        const profiles = await api.getSteamProfiles();
-        const match = Array.isArray(profiles) && profiles.find(p => p.steamId === steamId);
-        if (!match) {
-            return;
-        }
-
-        await api.removeSteamProfile(steamId);
-        log(`[Rep4Rep] Removed steamId: ${steamId}`);
-    } catch (err) {
-        log(`[ERROR] Failed to remove from Rep4Rep: ${describeApiError(err)}`);
-    }
-  }
-
-  log('Todos os perfis foram processados.');
-}
-
-async function addProfilesAndRun() {
-  const accounts = readAccountsFile();
-  if (!accounts.length) {
-    log('Nenhuma conta encontrada para adicionar e executar.', true);
-    return;
-  }
-
-  for (const [index, line] of accounts.entries()) {
-    try {
-      const { username, password, sharedSecret } = parseAccountLine(line);
-      log(`Adicionando e executando perfil ${index + 1} de ${accounts.length}: ${username}`);
-      await addProfileSetup(username, password, sharedSecret);
-      await autoRun();
-    } catch (error) {
-      log(`Erro ao processar perfil: ${error.message}`);
-    }
-
-    if (index !== accounts.length - 1) {
-      await sleep(30000, { announce: true });
-    const accounts = readAccountsFile();
-    const accountCount = accounts.length;
-    if (accountCount === 0) {
-        log('Nenhuma conta encontrada para adicionar e executar.', true);
-        return;
-    }
-
-    log(`Starting to add and run ${accountCount} profiles from file.`);
-
-    for (const [index, account] of accounts.entries()) {
-        const [username, password, sharedSecret] = account.split(':');
-        log(`Adding and running profile ${index + 1} of ${accountCount}: ${username}`);
-        
-        try {
-            if (!username || !password || !sharedSecret) {
-                throw new Error(`Invalid account format for ${account}`);
-            }
-            await addProfileSetup(username, password, sharedSecret);
-            await autoRun(); // Run tasks for the added profile
-            log(`Profile ${username} added and run successfully.`);
-        } catch (error) {
-            log(`Error adding and running profile ${username}: ${error.message}`);
-        }
-        
-        if (index !== accounts.length - 1) {
-            await sleep(30000); // Add delay to avoid throttling
-        }
-    }
-  }
-
-  log('Processo de adicionar e executar concluído.');
-}
-
-async function checkAndSyncProfiles() {
-  const profiles = await db.getAllProfiles();
-
-  for (const profile of profiles) {
-    log(`Verificando ${profile.username} (${profile.steamId})`);
-    const client = createSteamBot();
-
-    try {
-      const loginResult = await loginWithRetries(client, profile);
-      if (!loginResult.success) {
-        if (loginResult.requiresAction) {
-          log(`[${profile.username}] requer ação manual antes da sincronização.`);
-        } else if (loginResult.fatal) {
-          log(`[${profile.username}] removido por credenciais inválidas.`);
-
-    let profiles = await db.getAllProfiles();
-    for (const profile of profiles) {
-        log(`Verifying and syncing: ${profile.username} (${profile.steamId})`);
-        let client = steamBot();
-        try {
-            const loggedIn = await loginWithRetries(client, profile);
-            if (!loggedIn) {
-                log(`[${profile.username}] Não foi possível autenticar para sincronização.`);
-                continue;
-            }
-
-            let res = await syncWithRep4rep(client);
-            if (res === true || res === 'Steam profile already added/exists on rep4rep.') {
-                log(`[${profile.username}] Synced to Rep4Rep`);
-            } else {
-                log(`[${profile.username}] Failed to sync: ${res}`);
-            }
-        } catch (error) {
-            log(`[${profile.username}] Erro ao sincronizar: ${describeApiError(error)}`);
-
-            log(`[${profile.username}] Erro ao sincronizar: ${describeApiError(error)}`);
-
-            log(`[${profile.username}] Erro ao sincronizar: ${error.message}`);
-
-        }
+      } catch (error) {
+        log(`[${account.username}] Falha ao sincronizar perfil: ${describeApiError(error)}`);
         continue;
       }
+    }
 
-      const res = await syncWithRep4rep(client);
-      if (res === true || res === 'Steam profile already added/exists on rep4rep.') {
-        log(`[${profile.username}] sincronizado com sucesso.`);
-      } else {
-        log(`[${profile.username}] falhou ao sincronizar: ${res}`);
-      }
+    const remoteProfileId = resolveRemoteProfileId(remoteProfile);
+    if (!remoteProfileId) {
+      log(`[${account.username}] Não foi possível determinar o ID remoto do perfil.`);
+      continue;
+    }
+
+    const client = createSteamBot();
+    let loginResult;
+    try {
+      loginResult = await loginWithRetries(
+        client,
+        {
+          username: account.username,
+          password: account.password,
+          sharedSecret: account.sharedSecret,
+          cookies: profile.cookies,
+        },
+        null,
+        null,
+        null,
+        options.loginOptions,
+      );
     } catch (error) {
-      log(`[${profile.username}] Erro ao sincronizar: ${describeApiError(error)}`);
+      log(`[${account.username}] Falha ao autenticar: ${error.message}`);
+      continue;
+    }
+
+    if (!loginResult?.success) {
+      if (loginResult?.requiresAction) {
+        log(`[${account.username}] requer autenticação manual para atualizar cookies.`);
+      }
+      continue;
+    }
+
+    let comments = 0;
+    let stoppedEarly = false;
+    try {
+      const result = await runTasksForProfile({
+        profile,
+        client,
+        remoteProfileId,
+        apiClient,
+        apiToken,
+        maxComments: Math.max(1, maxCommentsPerAccount),
+        commentDelay,
+        onTaskComplete,
+      });
+      comments = result?.commentsPosted ?? 0;
+      stoppedEarly = Boolean(result?.stoppedEarly);
+    } catch (error) {
+      log(`[${account.username}] Falha ao processar tarefas: ${error.message}`);
+    }
+
+    summary.perAccount.push({
+      username: account.username,
+      steamId: profile.steamId,
+      comments,
+      stoppedEarly,
+    });
+    summary.totalComments += comments;
+
+    if (stoppedEarly) {
+      log('Limite de execução atingido. Encerrando autoRun.');
+      break;
+    }
+
+    if (index < accounts.length - 1) {
+      await sleep(loginDelay);
     }
   }
 
-  log('Sincronização concluída.');
+  log(`✅ autoRun concluído. Total de comentários enviados: ${summary.totalComments}`);
+  return summary;
+}
+
+async function authAllProfiles(options = {}) {
+  const profiles = await db.getAllProfiles();
+  if (!profiles.length) {
+    log('Nenhum perfil cadastrado.');
+    return;
+  }
+
+  for (const profile of profiles) {
+    const client = createSteamBot();
+    let loginResult;
+    try {
+      loginResult = await loginWithRetries(client, profile, null, null, null, options.loginOptions);
+    } catch (error) {
+      log(`[${profile.username}] Falha ao autenticar: ${error.message}`);
+      continue;
+    }
+
+    if (!loginResult?.success) {
+      if (loginResult?.requiresAction) {
+        log(`[${profile.username}] requer autenticação manual.`);
+      }
+      continue;
+    }
+
+    try {
+      const cookies = await client.getCookies();
+      if (cookies?.length) {
+        await db.updateCookies(profile.username, cookies);
+      }
+      log(`[${profile.username}] autenticado com sucesso.`);
+    } catch (error) {
+      log(`[${profile.username}] Falha ao atualizar cookies: ${error.message}`);
+    }
+  }
+}
+
+async function removeProfile(username, options = {}) {
+  const user = String(username || '').trim();
+  if (!user) {
+    throw new Error('Informe o username a remover.');
+  }
+
+  const profiles = await db.getAllProfiles();
+  const profile = profiles.find((item) => item.username === user);
+  if (!profile) {
+    log(`[${user}] Perfil não encontrado.`);
+  } else if (profile.steamId) {
+    await removeFromRep4Rep(profile.steamId, { apiToken: options.apiToken });
+  }
+
+  await db.removeProfile(user);
+  removeFromAccountsFile(user);
+  log(`[${user}] Removido do sistema.`);
+}
+
+async function checkAndSyncProfiles(options = {}) {
+  const { apiClient = api, apiToken = null } = options;
+  const profiles = await db.getAllProfiles();
+  if (!profiles.length) {
+    log('Nenhum perfil cadastrado.');
+    return;
+  }
+
+  let remoteProfiles;
+  try {
+    remoteProfiles = await apiClient.getSteamProfiles({ token: apiToken });
+  } catch (error) {
+    log(`[API] Falha ao obter perfis: ${describeApiError(error)}`);
+    return;
+  }
+
+  const remoteMap = new Map(remoteProfiles.map((item) => [String(item.steamId), item]));
+
+  for (const profile of profiles) {
+    if (!remoteMap.has(String(profile.steamId))) {
+      log(`[${profile.username}] não encontrado no Rep4Rep. Tentando sincronizar.`);
+      try {
+        await apiClient.addSteamProfile(profile.steamId, { token: apiToken });
+        log(`[${profile.username}] sincronizado com sucesso.`);
+      } catch (error) {
+        log(`[${profile.username}] Falha ao sincronizar: ${describeApiError(error)}`);
+      }
+    }
+  }
 }
 
 async function checkCommentAvailability() {
   const profiles = await db.getAllProfiles();
-  for (const profile of profiles) {
-    const commentsInLast24Hours = await db.getCommentsInLast24Hours(profile.steamId);
-    const commentsAvailable = Math.max(10 - commentsInLast24Hours, 0);
-    log(`[${profile.username}] pode fazer mais ${commentsAvailable} comentários nas próximas 24 horas.`);
+  if (!profiles.length) {
+    log('Nenhum perfil cadastrado.');
+    return;
   }
-  log('Verificação de disponibilidade concluída.');
+
+  const rows = [['Usuário', 'Horas desde último comentário', 'Status']];
+  for (const profile of profiles) {
+    const hours = profile.lastComment
+      ? moment().diff(moment(profile.lastComment), 'hours', true)
+      : Infinity;
+    const status = hours >= 24 ? 'Pronto' : 'Cooldown';
+    rows.push([
+      profile.username,
+      Number.isFinite(hours) ? hours.toFixed(1) : '∞',
+      status,
+    ]);
+  }
+
+  console.log(table(rows));
 }
 
-async function verifyProfileStatus() {
+async function verifyProfileStatus(options = {}) {
   const profiles = await db.getAllProfiles();
+  if (!profiles.length) {
+    log('Nenhum perfil cadastrado.');
+    return;
+  }
+
+  const rows = [['Usuário', 'Status']];
   for (const profile of profiles) {
     const client = createSteamBot();
     try {
-      const cookies = parseStoredCookies(profile.cookies, profile.username);
-      await client.steamLogin(
-        profile.username,
-        profile.password,
-        null,
-        profile.sharedSecret,
-        null,
-        cookies.length ? cookies : null
-      );
-      const isLoggedIn = client.status === statusMessage.loggedIn || (await client.isLoggedIn());
-      log(`[${profile.username}] ${isLoggedIn ? '✅ Logado' : '❌ Não logado'}`);
+      const loginResult = await loginWithRetries(client, profile, null, null, null, {
+        maxRetries: 1,
+        ...(options.loginOptions || {}),
+      });
+      if (loginResult?.success) {
+        rows.push([profile.username, 'OK']);
+      } else if (loginResult?.requiresAction) {
+        rows.push([profile.username, 'Ação manual']);
+      } else if (loginResult?.fatal) {
+        rows.push([profile.username, `Inválido: ${loginResult.reason}`]);
+      } else {
+        rows.push([profile.username, 'Falha desconhecida']);
+      }
     } catch (error) {
-      log(`[${profile.username}] ❌ Erro ao verificar login: ${error.message}`);
-    const profiles = await db.getAllProfiles();
-    for (const profile of profiles) {
-        const client = steamBot();
-        try {
-            const cookies = parseStoredCookies(profile.cookies, profile.username);
-            await client.steamLogin(
-                profile.username,
-                profile.password,
-                null,
-                profile.sharedSecret,
-                null,
-                cookies.length ? cookies : null
-            );
-            const isLoggedIn = client.status === 4 || await client.isLoggedIn();
-            log(`[${profile.username}] ${isLoggedIn ? '✅ Logado' : '❌ Não logado'}`);
-        } catch (err) {
-            log(`[${profile.username}] ❌ Erro ao verificar login: ${err.message}`);
-        }
+      rows.push([profile.username, `Erro: ${error.message}`]);
     }
   }
+
+  console.log(table(rows));
 }
 
 async function exportProfilesToCSV() {
   const profiles = await db.getAllProfiles();
-  const lines = ['steamId,username,lastComment'];
-  profiles.forEach((profile) => lines.push(`${profile.steamId},${profile.username},${profile.lastComment ?? ''}`));
-  const filePath = path.join(ROOT_DIR, 'exported_profiles.csv');
-  fs.writeFileSync(filePath, lines.join('\n'));
-  log(`Perfis exportados para: ${filePath}`);
+  if (!profiles.length) {
+    log('Nenhum perfil cadastrado para exportar.');
+    return null;
+  }
+
+  ensureDirectory(EXPORTS_DIR);
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const filePath = path.join(EXPORTS_DIR, `profiles-${timestamp}.csv`);
+  const lines = ['username,steamId,lastComment,commentsLast24h'];
+
+  for (const profile of profiles) {
+    const count24h = await db.getCommentsInLast24Hours(profile.steamId);
+    const lastComment = profile.lastComment ? new Date(profile.lastComment).toISOString() : '';
+    const row = [
+      JSON.stringify(profile.username ?? ''),
+      JSON.stringify(profile.steamId ?? ''),
+      JSON.stringify(lastComment),
+      JSON.stringify(count24h),
+    ].join(',');
+    lines.push(row);
+  }
+
+  fs.writeFileSync(filePath, `${lines.join('\n')}\n`, 'utf8');
+  log(`📄 Exportação concluída em ${filePath}`);
+  return filePath;
 }
 
 async function clearInvalidAccounts() {
-  const date = new Date().toISOString().split('T')[0];
-  const logFile = path.join(LOGS_DIR, `invalid-${date}.log`);
-  if (!fs.existsSync(logFile)) {
-    log('Nenhum arquivo de inválidos encontrado.');
-    return;
+  if (!fs.existsSync(ACCOUNTS_PATH)) {
+    log('accounts.txt não encontrado.');
+    return { removed: 0, total: 0 };
   }
-  const lines = fs.readFileSync(logFile, 'utf-8').split('\n').filter(Boolean);
+
+  const lines = fs.readFileSync(ACCOUNTS_PATH, 'utf8').split(/\r?\n/).filter(Boolean);
+  const seen = new Set();
+  const valid = [];
+  let removed = 0;
+
   for (const line of lines) {
-    const [, userWithReason] = line.split(']');
-    const username = userWithReason ? userWithReason.split(' - ')[0].trim() : null;
-    if (!username) continue;
-    await db.removeProfile(username);
-    removeFromAccountsFile(username);
-    log(`Removido inválido: ${username}`);
+    try {
+      const account = parseAccountLine(line);
+      if (seen.has(account.username)) {
+        removed += 1;
+        continue;
+      }
+      seen.add(account.username);
+      valid.push(`${account.username}:${account.password}:${account.sharedSecret}`);
+    } catch (error) {
+      removed += 1;
+    }
   }
-  log('Perfis inválidos removidos.');
+
+  fs.writeFileSync(ACCOUNTS_PATH, valid.length ? `${valid.join('\n')}\n` : '');
+  log(`Limpeza concluída. ${removed} linha(s) removida(s).`);
+  return { removed, total: lines.length };
 }
 
 async function collectUsageStats() {
@@ -1544,44 +855,13 @@ async function collectUsageStats() {
   };
 
   for (const profile of profiles) {
-    const lastCommentMoment = profile.lastComment ? moment(profile.lastComment) : null;
-    const diff = lastCommentMoment ? moment().diff(lastCommentMoment, 'hours') : Infinity;
-    if (!lastCommentMoment || diff >= 24) {
+    const hours = profile.lastComment
+      ? moment().diff(moment(profile.lastComment), 'hours', true)
+      : Infinity;
+    if (hours >= 24) {
       totals.ready += 1;
     } else {
       totals.coolingDown += 1;
-    const date = new Date().toISOString().split('T')[0];
-    const logFile = path.join(LOGS_DIR, `invalid-${date}.log`);
-    if (!fs.existsSync(logFile)) return log('Nenhum arquivo de inválidos encontrado.');
-    const lines = fs.readFileSync(logFile, 'utf-8').split('\n').filter(Boolean);
-    for (const line of lines) {
-        const username = line.split(' - ')[0].replace('[', '').split(']')[1].trim();
-        await db.removeProfile(username);
-        removeFromAccountsFile(username);
-        log(`Removido inválido: ${username}`);
-    }
-    log('Perfis inválidos removidos.');
-}
-
-async function collectUsageStats() {
-    const profiles = await db.getAllProfiles();
-    const totals = {
-        total: profiles.length,
-        ready: 0,
-        coolingDown: 0,
-        commentsLast24h: 0,
-    };
-
-    for (const profile of profiles) {
-        const lastCommentMoment = profile.lastComment ? moment(profile.lastComment) : null;
-        const diff = lastCommentMoment ? moment().diff(lastCommentMoment, 'hours') : Infinity;
-        if (!lastCommentMoment || diff >= 24) {
-            totals.ready++;
-        } else {
-            totals.coolingDown++;
-        }
-        const count = await db.getCommentsInLast24Hours(profile.steamId);
-        totals.commentsLast24h += count;
     }
     const count = await db.getCommentsInLast24Hours(profile.steamId);
     totals.commentsLast24h += count;
@@ -1599,52 +879,24 @@ async function usageStats() {
   log(`Total de comentários nas últimas 24h: ${stats.commentsLast24h}`);
 }
 
-async function resetProfileCookies() {
+async function resetProfileCookies(options = {}) {
   const profiles = await db.getAllProfiles();
   for (const profile of profiles) {
     const client = createSteamBot();
     try {
-      const loginResult = await loginWithRetries(client, profile);
-      if (!loginResult.success) {
-        if (loginResult.requiresAction) {
+      const loginResult = await loginWithRetries(client, profile, null, null, null, options.loginOptions);
+      if (!loginResult?.success) {
+        if (loginResult?.requiresAction) {
           log(`[${profile.username}] requer autenticação manual para atualizar cookies.`);
-        } else if (loginResult.fatal) {
-          log(`[${profile.username}] removido por credenciais inválidas.`);
-    return totals;
-}
-
-async function usageStats() {
-    const stats = await collectUsageStats();
-    log('📊 Estatísticas de Uso:');
-    log(`Total perfis: ${stats.total}`);
-    log(`Perfis ativos (prontos para comentar): ${stats.ready}`);
-    log(`Perfis aguardando cooldown: ${stats.coolingDown}`);
-    log(`Total de comentários nas últimas 24h: ${stats.commentsLast24h}`);
-}
-
-async function resetProfileCookies() {
-    const profiles = await db.getAllProfiles();
-    for (const profile of profiles) {
-        const client = steamBot();
-        try {
-            const loggedIn = await loginWithRetries(client, profile);
-            if (!loggedIn) {
-                log(`[${profile.username}] Não foi possível autenticar para atualizar cookies.`);
-                continue;
-            }
-
-            const cookies = await client.getCookies();
-            await db.updateCookies(profile.username, cookies);
-            log(`[${profile.username}] Cookies atualizados`);
-        } catch (err) {
-            log(`[${profile.username}] Falha ao resetar cookies: ${err.message}`);
         }
         continue;
       }
 
       const cookies = await client.getCookies();
-      await db.updateCookies(profile.username, cookies);
-      log(`[${profile.username}] Cookies atualizados.`);
+      if (cookies?.length) {
+        await db.updateCookies(profile.username, cookies);
+        log(`[${profile.username}] Cookies atualizados.`);
+      }
     } catch (error) {
       log(`[${profile.username}] Falha ao resetar cookies: ${error.message}`);
     }
@@ -1666,7 +918,7 @@ async function backupDatabase() {
   }
 
   ensureDirectory(BACKUPS_DIR);
-  const timestamp = new Date().toISOString().replace(/:/g, '-');
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
   const dest = path.join(BACKUPS_DIR, `db-${timestamp}.sqlite`);
 
   try {
@@ -1689,7 +941,7 @@ module.exports = {
   loginWithRetries,
   statusMessage,
   showAllProfiles,
-  addProfileSetup,
+  addProfileSetup: addProfilesFromFile,
   authAllProfiles,
   removeProfile,
   autoRun,
@@ -1708,61 +960,4 @@ module.exports = {
   readAccountsFile,
   parseStoredCookies,
   closeReadline,
-
-    try {
-        await db.init();
-    } catch (error) {
-        log(`❌ Falha ao preparar o banco para backup: ${error.message}`, true);
-        return null;
-    }
-
-    const src = db.getDatabasePath();
-    if (!fs.existsSync(src)) {
-        log('⚠️ Nenhum banco de dados encontrado para backup.', true);
-        return null;
-    }
-
-    const destDir = path.join(__dirname, '..', 'backups');
-    if (!fs.existsSync(destDir)) {
-        fs.mkdirSync(destDir, { recursive: true });
-    }
-
-    const timestamp = new Date().toISOString().replace(/:/g, '-');
-    const dest = path.join(destDir, `db-${timestamp}.sqlite`);
-
-    try {
-        fs.copyFileSync(src, dest);
-    } catch (error) {
-        log(`❌ Falha ao criar backup: ${error.message}`, true);
-        return null;
-    }
-
-    log(`📦 Backup criado em: ${dest}`);
-    return dest;
-}
-
-module.exports = { 
-    log,
-    logToFile,
-    logInvalidAccount,
-    removeFromAccountsFile,
-    removeFromRep4Rep, 
-    loginWithRetries,
-    statusMessage,
-    showAllProfiles,
-    addProfileSetup,
-    authAllProfiles,
-    removeProfile,
-    autoRun,
-    addProfilesFromFile,
-    addProfilesAndRun,
-    checkAndSyncProfiles,
-    checkCommentAvailability,
-    verifyProfileStatus,
-    exportProfilesToCSV,
-    clearInvalidAccounts,
-    usageStats,
-    collectUsageStats,
-    resetProfileCookies,
-    backupDatabase
 };

--- a/web/public/panel.js
+++ b/web/public/panel.js
@@ -192,6 +192,20 @@
           outputEl.textContent = `${message}\n\n${JSON.stringify(data.stats, null, 2)}`;
         } else if (data.filePath) {
           outputEl.textContent = `${message}\nArquivo salvo em: ${data.filePath}`;
+        } else if (data.summary) {
+          const perAccount = Array.isArray(data.summary.perAccount)
+            ? data.summary.perAccount
+            : [];
+          const lines = [
+            message,
+            '',
+            `Total de comentários: ${data.summary.totalComments ?? 0}`,
+          ];
+          perAccount.forEach((item) => {
+            const suffix = item.stoppedEarly ? ' (limite atingido)' : '';
+            lines.push(`- ${item.username || 'desconhecido'}: ${item.comments ?? 0}${suffix}`);
+          });
+          outputEl.textContent = lines.join('\n');
         } else {
           outputEl.textContent = message;
         }

--- a/web/routes/panel.js
+++ b/web/routes/panel.js
@@ -3,26 +3,21 @@ const router = express.Router();
 const basicAuth = require('basic-auth');
 const fs = require('fs');
 const path = require('path');
+
 const auth = require('../auth');
+const userStore = require('../services/userStore');
 const {
   autoRun,
   collectUsageStats,
   backupDatabase,
   describeApiError,
 } = require('../../src/util.cjs');
-const userStore = require('../services/userStore');
 
 const LOGS_DIR = path.join(__dirname, '..', '..', 'logs');
 
 userStore.ensureDataFile().catch((error) => {
   console.error('[Painel] Falha ao preparar storage de usuários:', error);
 });
-const auth = require('../auth');
-const {
-    autoRun,
-    collectUsageStats,
-    backupDatabase
-} = require('../../src/util.cjs');
 
 router.use((req, res, next) => {
   const user = basicAuth(req);
@@ -95,8 +90,8 @@ router.post('/api/admin/run', async (req, res) => {
 
   const handlers = {
     autoRun: async () => {
-      await autoRun();
-      return { message: '✅ autoRun concluído. Verifique os logs para detalhes.' };
+      const summary = await autoRun();
+      return { message: '✅ autoRun concluído. Verifique os logs para detalhes.', summary };
     },
     stats: async () => {
       const stats = await collectUsageStats();
@@ -176,62 +171,6 @@ router.post('/api/admin/users/:id/credits', async (req, res) => {
     const status = error.message.includes('não encontrado') ? 404 : 400;
     res.status(status).json({ success: false, error: error.message });
   }
-router.get('/run/:command', async (req, res) => {
-    const cmd = req.params.command;
-
-    const handlers = {
-        autoRun: async () => {
-            await autoRun();
-            return '✅ autoRun concluído. Verifique os logs para detalhes.';
-        },
-        stats: async () => {
-            const stats = await collectUsageStats();
-            return [
-                '📊 Estatísticas de Uso',
-                `Total de perfis: ${stats.total}`,
-                `Perfis prontos para comentar: ${stats.ready}`,
-                `Perfis aguardando cooldown: ${stats.coolingDown}`,
-                `Comentários nas últimas 24h: ${stats.commentsLast24h}`
-            ].join('\n');
-        },
-        backup: async () => {
-            const filePath = await backupDatabase();
-            if (!filePath) {
-                return '⚠️ Nenhum banco de dados encontrado para backup.';
-            }
-            const filePath = backupDatabase();
-            return `📦 Backup criado em: ${filePath}`;
-        }
-    };
-
-    const handler = handlers[cmd];
-    if (!handler) {
-        return res.status(400).send('❌ Comando inválido.');
-    }
-
-    try {
-        const output = await handler();
-        res.type('text/plain').send(output);
-    } catch (error) {
-        console.error(`[Painel] Falha ao executar comando ${cmd}:`, error);
-        res.status(500).send(`Erro ao executar comando: ${error.message}`);
-    }
-});
-
-router.get('/logs', (req, res) => {
-    const logDir = path.join(__dirname, '..', '..', 'logs');
-
-    if (!fs.existsSync(logDir)) {
-        return res.render('logs', { logs: [] });
-    }
-
-    const files = fs.readdirSync(logDir).filter(f => f.endsWith('.log'));
-    const logs = files.map(f => ({
-        name: f,
-        content: fs.readFileSync(path.join(logDir, f), 'utf8')
-    }));
-
-    res.render('logs', { logs });
 });
 
 module.exports = router;

--- a/web/routes/user.js
+++ b/web/routes/user.js
@@ -1,0 +1,113 @@
+const express = require('express');
+const router = express.Router();
+
+const userStore = require('../services/userStore');
+const { autoRun, collectUsageStats } = require('../../src/util.cjs');
+
+function extractAuth(req) {
+  const userId =
+    req.header('x-user-id') ||
+    req.body?.userId ||
+    req.query?.userId ||
+    null;
+  const token =
+    req.header('x-user-token') ||
+    req.body?.token ||
+    req.body?.apiToken ||
+    req.query?.token ||
+    null;
+  return { userId: userId ? String(userId) : null, token: token ? String(token) : null };
+}
+
+router.use(async (req, res, next) => {
+  try {
+    const { userId, token } = extractAuth(req);
+    const user = await userStore.authenticateUser({ userId, token });
+    if (!user) {
+      return res.status(401).json({ success: false, error: 'Credenciais inválidas.' });
+    }
+    req.user = user;
+    next();
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get('/me', async (req, res) => {
+  const { user } = req;
+  res.json({
+    success: true,
+    user: {
+      id: user.id,
+      displayName: user.displayName,
+      email: user.email,
+      credits: user.credits,
+      status: user.status,
+      role: user.role,
+      rep4repKey: user.rep4repKey,
+    },
+  });
+});
+
+router.post('/run', async (req, res) => {
+  const { command = 'autoRun' } = req.body || {};
+  const allowedCommands = new Set(['autoRun', 'stats']);
+  if (!allowedCommands.has(command)) {
+    return res.status(400).json({ success: false, error: 'Comando não permitido para usuários.' });
+  }
+
+  if (command === 'stats') {
+    try {
+      const stats = await collectUsageStats();
+      return res.json({ success: true, stats });
+    } catch (error) {
+      return res.status(500).json({ success: false, error: error.message });
+    }
+  }
+
+  if (req.user.credits <= 0) {
+    return res.status(402).json({ success: false, error: 'Créditos insuficientes.' });
+  }
+
+  if (!req.user.rep4repKey) {
+    return res.status(400).json({ success: false, error: 'Defina a chave Rep4Rep antes de executar comandos.' });
+  }
+
+  const creditLimit = req.user.credits;
+  let usedCredits = 0;
+
+  try {
+    const summary = await autoRun({
+      apiToken: req.user.rep4repKey,
+      onTaskComplete: () => {
+        usedCredits += 1;
+        if (usedCredits >= creditLimit) {
+          return false;
+        }
+        return true;
+      },
+    });
+
+    const consumed = Math.min(summary.totalComments ?? usedCredits, creditLimit);
+    let updatedUser = req.user;
+    if (consumed > 0) {
+      updatedUser = await userStore.consumeCredits(req.user.id, consumed);
+    }
+
+    res.json({
+      success: true,
+      message: 'Execução concluída.',
+      summary,
+      creditsConsumed: consumed,
+      remainingCredits: updatedUser.credits,
+    });
+  } catch (error) {
+    if (/Créditos insuficientes/.test(error.message)) {
+      return res.status(402).json({ success: false, error: error.message });
+    }
+    console.error('[API usuário] Falha ao executar comando:', error);
+    res.status(500).json({ success: false, error: error.message });
+  }
+});
+
+module.exports = router;

--- a/web/server.js
+++ b/web/server.js
@@ -2,6 +2,7 @@ require('dotenv').config();
 const express = require('express');
 const path = require('path');
 const panelRouter = require('./routes/panel');
+const userRouter = require('./routes/user');
 const app = express();
 
 app.use(express.urlencoded({ extended: true }));
@@ -12,6 +13,7 @@ app.set('views', path.join(__dirname, 'views'));
 
 app.locals.siteName = 'Rep4Rep Control Center';
 
+app.use('/api/user', userRouter);
 app.use('/', panelRouter);
 
 const PORT = process.env.PORT || 3000;

--- a/web/views/dashboard.ejs
+++ b/web/views/dashboard.ejs
@@ -8,7 +8,7 @@
             <button class="btn btn--secondary" data-command="backup">💾 Criar backup</button>
             <a class="btn btn--ghost" href="/logs">📜 Ver logs</a>
         </div>
-        <p class="hero__hint">Dica: configure o arquivo <code>accounts.txt</code> e garanta que o <code>REP4REP_KEY</code> esteja definido antes de rodar as automações.</p>
+        <p class="hero__hint">Dica: configure o arquivo <code>accounts.txt</code> e garanta que o <code>REP4REP_KEY</code> está definido antes de rodar as automações.</p>
     </div>
     <aside class="hero__card">
         <h2>Resumo rápido</h2>
@@ -119,7 +119,7 @@
                                         <span><%= user.email %></span>
                                     </div>
                                     <div class="user-meta">
-                                        <span class="badge badge--status badge--<%= user.status %>"><%= user.status %></span>
+                                        <span class="badge badge--status badge--<%= ['active','blocked','pending'].includes(user.status) ? user.status : 'muted' %>"><%= user.status %></span>
                                         <% if (user.rep4repKey) { %>
                                             <span class="badge">Key definida</span>
                                         <% } else { %>
@@ -153,20 +153,3 @@
 <div class="toast" data-toast hidden></div>
 
 <%- include('partials/layout-end', { includePanelScript: true }) %>
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Painel Rep4Rep</title>
-    <link rel="stylesheet" href="/style.css">
-</head>
-<body>
-    <h1>Painel do Bot Rep4Rep</h1>
-    <p>Os comandos abaixo executam diretamente no servidor. Aguarde o carregamento após clicar.</p>
-    <ul>
-        <li><a href="/run/autoRun" target="_blank">▶️ Rodar autoRun</a></li>
-        <li><a href="/run/stats" target="_blank">📊 Ver estatísticas</a></li>
-        <li><a href="/run/backup" target="_blank">💾 Backup</a></li>
-        <li><a href="/logs" target="_blank">📜 Ver logs</a></li>
-    </ul>
-</body>
-</html>


### PR DESCRIPTION
## Resumo
- reescreve utilidades do bot para eliminar duplicações, melhorar logs e permitir interrupção com base em créditos
- flexibiliza cliente da API Rep4Rep com suporte a tokens por requisição e adiciona API pública para usuários com consumo automático de créditos
- reorganiza o painel web, atualiza gerenciamento de usuários/créditos e adiciona exportações/estatísticas consistentes

## Testes
- `node -e "require('./src/util.cjs')"`
- `node -e "require('./web/routes/user')"`


------
https://chatgpt.com/codex/tasks/task_e_68ca8e94e0548325a64123b4e08dca70