### PR TITLE
Implement prioritized scheduling and client safeguards

### DIFF
--- a/main.cjs
+++ b/main.cjs
@@ -8,6 +8,8 @@ const {
     autoRun,
     addProfilesFromFile,
     addProfilesAndRun,
+    runFullCycle,
+    prioritizedAutoRun,
     checkAndSyncProfiles,
     checkCommentAvailability,
     verifyProfileStatus,
@@ -31,7 +33,7 @@ async function mainMenu() {
     log("==================");
     log("1. Mostrar perfis");
     log("2. Autorizar todos perfis");
-    log("3. Executar autoRun");
+    log("3. Executar autoRun prioritário");
     log("4. Adicionar perfis do arquivo");
     log("5. Adicionar perfis e rodar");
     log("6. Remover perfil");
@@ -43,6 +45,7 @@ async function mainMenu() {
     log("12. Estatísticas de uso");
     log("13. Resetar cookies dos perfis");
     log("14. Backup do banco de dados");
+    log("15. Ciclo completo (adicionar, rodar e remover)");
     log("0. Sair", true);
 
     rl.question("Escolha uma opção: ", async (opt) => {
@@ -54,13 +57,23 @@ async function mainMenu() {
                 await authAllProfiles();
                 break;
             case "3":
-                await autoRun();
+                await prioritizedAutoRun({
+                    accountLimit: 100,
+                    maxCommentsPerAccount: 1000,
+                    clientFilter: (user) => user.role !== 'admin',
+                });
                 break;
             case "4":
                 await addProfilesFromFile();
                 break;
             case "5":
                 await addProfilesAndRun();
+                break;
+            case "15":
+                await runFullCycle({
+                    maxAccounts: 100,
+                    maxCommentsPerAccount: 1000,
+                });
                 break;
             case "6":
                 rl.question("Usuário a remover: ", async (username) => {


### PR DESCRIPTION
## Summary
- introduce a prioritized execution flow that runs owner orders before clients and adds a CLI option for the full add/run/remove cycle with enforced limits
- clamp execution limits to 100 accounts/1k comments, clean up remote profiles after client runs, and require Rep4Rep profiles before web-triggered jobs
- refactor the user store to operate from SQLite with legacy migration support and expose admin lookup for the panel to source its Rep4Rep key

## Testing
- node -e "require('./src/util.cjs')"
- node -e "require('./web/routes/user.js')"
- node -e "(async () => { const store = require('./web/services/userStore.js'); const users = await store.listUsers(); console.log('users', users.length); process.exit(0); })().catch(err => { console.error(err); process.exit(1); });"

------
https://chatgpt.com/codex/tasks/task_e_68caa95a8f088325baccdd0faaabbaf7