### PR TITLE
Add keep-alive mode, scheduled backups, and Windows helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,343 +1,156 @@
 # 🤖 Rep4Rep Bot CLI + Painel Web
 
-Automação de comentários no Steam via [Rep4Rep.com](https://rep4rep.com) com suporte a múltiplas contas, controle de créditos por cliente e painel web para administração e uso seguro por terceiros.
-
----
+Automação de comentários para Steam integrada ao [Rep4Rep.com](https://rep4rep.com) com modo terminal, painel administrativo e fluxo seguro para vender execuções a clientes sem expor suas contas.
 
 ## 📚 Índice rápido
-
-1. [Requisitos](#-requisitos)
-2. [Instalação e configuração](#-instalação-e-configuração)
-3. [Estrutura do projeto](#-estrutura-do-projeto)
-4. [Comandos da CLI](#-comandos-da-clicjs)
-5. [Como funciona o painel web](#-como-funciona-o-painel-web)
+1. [Visão geral](#-visão-geral)
+2. [Requisitos](#-requisitos)
+3. [Instalação e configuração](#-instalação-e-configuração)
+4. [Fluxo de trabalho](#-fluxo-de-trabalho)
+5. [Comandos da CLI](#-comandos-da-cli)
+6. [Prioridade, limites e limpeza](#-prioridade-limites-e-limpeza)
+7. [Painel web](#-painel-web)
    - [Acesso do administrador](#acesso-do-administrador)
-   - [Portal do cliente e fluxo de login](#portal-do-cliente-e-fluxo-de-login)
-   - [Gerenciamento de clientes e créditos](#gerenciamento-de-clientes-e-créditos)
-   - [Fluxo de créditos e permissões](#fluxo-de-créditos-e-permissões)
-   - [API pública para clientes](#api-pública-para-clientes)
-6. [Banco de dados e armazenamento](#-banco-de-dados-e-armazenamento)
-7. [Variáveis de ambiente](#-variáveis-de-ambiente)
-8. [Scripts disponíveis](#-scripts-disponíveis)
-9. [Hospedagem e domínio personalizado](#-hospedagem-e-domínio-personalizado)
-10. [Suporte](#-suporte)
-   - [Gerenciamento de clientes e créditos](#gerenciamento-de-clientes-e-créditos)
-   - [Fluxo de créditos e permissões](#fluxo-de-créditos-e-permissões)
-   - [API pública para clientes](#api-pública-para-clientes)
-6. [Variáveis de ambiente](#-variáveis-de-ambiente)
-7. [Scripts disponíveis](#-scripts-disponíveis)
-8. [Suporte](#-suporte)
+   - [Portal do cliente](#portal-do-cliente)
+   - [Créditos e permissões](#créditos-e-permissões)
+8. [Armazenamento e segurança](#-armazenamento-e-segurança)
+9. [Variáveis de ambiente](#-variáveis-de-ambiente)
+10. [Scripts disponíveis](#-scripts-disponíveis)
+11. [Dicas e suporte](#-dicas-e-suporte)
 
----
-
-## 🛠️ Requisitos
-
-- Node.js v18 ou superior
-- Conta ativa no [rep4rep.com](https://rep4rep.com)
-- Arquivo `.env` configurado (veja [Variáveis de ambiente](#-variáveis-de-ambiente))
-- Arquivo `accounts.txt` com cada conta Steam no formato `username:password:shared_secret`
-
----
-
-## ⚙️ Instalação e configuração
-
-1. Copie `env.example` para `.env` e ajuste as credenciais.
-2. Instale as dependências do bot e do painel:
-   ```bash
-   npm install
-   cd web && npm install
-   ```
-3. Preencha `accounts.txt` com as contas que farão comentários.
-4. Na primeira execução o painel cria a tabela `app_user` dentro de `steamprofiles.db`. Se você possui um `data/users.json` antigo ele será migrado automaticamente, mas novos clientes devem ser cadastrados pelo painel (`/admin`) ou via API.
-
-Inicie apenas o bot com `npm run bot`, o painel com `npm run painel` ou tudo junto via `npm run dev`.
-
----
-
-
----
-
-## ⚙️ Instalação e configuração
-
-1. Copie `env.example` para `.env` e ajuste as credenciais.
-2. Instale as dependências do bot e do painel:
-   ```bash
-   npm install
-   cd web && npm install
-   ```
-3. Preencha `accounts.txt` com as contas que farão comentários.
-4. Opcional: ajuste `data/users.json` para começar com seus próprios clientes.
-
-Inicie apenas o bot com `npm run bot`, o painel com `npm run painel` ou tudo junto via `npm run dev`.
-
----
-
-## 📁 Estrutura do projeto
+## 📌 Visão geral
+- `main.cjs` oferece a CLI completa para administrar contas, rodar execuções prioritárias e disparar o ciclo completo de adicionar ➜ comentar ➜ remover perfis.
+- `src/` contém o núcleo do bot (login Steam, cliente Rep4Rep, agendador prioritário e utilidades de banco).
+- `web/` disponibiliza painel Express + EJS com autenticação básica para o administrador e portal de autoatendimento para clientes.
+- O banco SQLite (`steamprofiles.db`) guarda perfis Steam, cookies, histórico de comentários e os usuários do painel.
 
 ```
 📦 root
-├── main.cjs               # Interface CLI
-├── src/
-│   ├── util.cjs           # Funções principais do bot e autoRun
-│   ├── api.cjs            # Cliente Rep4Rep com suporte a múltiplas keys
-│   ├── steamBot.cjs       # Login/Postagem de comentários
-│   └── db.cjs             # Banco SQLite com perfis e status
-├── web/                   # Painel administrativo (Express + EJS + JS/CSS)
-├── data/                  # Exportações, backups e arquivos auxiliares
-├── accounts.txt           # Contas Steam usadas nas automações
-├── .env                   # Configurações sensíveis
-├── steamprofiles.db       # Banco SQLite com perfis Steam e usuários do painel
-├── data/users.json        # Base de clientes, créditos e tokens de API
-├── accounts.txt           # Contas Steam usadas nas automações
-├── .env                   # Configurações sensíveis
-├── steamprofiles.db       # Banco local dos perfis sincronizados
-└── logs/                  # Logs das execuções
+├── accounts.txt          # Lista de contas Steam (username:senha:shared_secret)
+├── main.cjs              # Menu da CLI
+├── src/                  # Bot, autoRun, integrações com Rep4Rep e banco
+├── web/                  # Painel admin + portal do cliente (Express)
+├── data/
+│   ├── exports/          # Arquivos CSV gerados pela CLI
+│   └── users.json        # Arquivo legacy somente para referência
+├── logs/                 # Registros diários de execuções
+├── backups/              # Backups criados pela CLI/painel
+├── steamprofiles.db      # Banco SQLite principal
+├── package.json          # Scripts principais do projeto
+└── env.example           # Exemplo de configuração .env
 ```
 
----
+## 🛠️ Requisitos
+- Node.js v18 ou superior.
+- Conta ativa no [Rep4Rep](https://rep4rep.com) com chave de API.
+- Arquivo `accounts.txt` preenchido com as contas Steam que irão comentar.
+- Variáveis de ambiente configuradas (veja [Variáveis de ambiente](#-variáveis-de-ambiente)).
 
-## 🚀 Comandos da `main.cjs`
+## ⚙️ Instalação e configuração
+1. Copie `env.example` para `.env` e ajuste credenciais, delays e limites desejados.
+2. Instale dependências:
+   ```bash
+   npm install
+   cd web && npm install
+   ```
+   > 💡 Usuários Windows podem executar `install-bot.bat` para automatizar a criação do `.env` e a instalação das dependências da raiz e do painel.
+3. Preencha `accounts.txt` com uma conta por linha (`username:senha:shared_secret`).
+4. (Opcional) Popule `data/users.json` apenas como semente. Na primeira execução os dados são migrados para o SQLite automaticamente.
+5. Inicie apenas o bot (`npm run bot`), somente o painel (`npm run painel`) ou ambos (`npm run dev`). No Windows, o arquivo `start-bot.bat` oferece um menu para iniciar apenas a CLI ou CLI + painel (com ou sem abrir o navegador).
 
-| Nº  | Ação                                              |
-|----|----------------------------------------------------|
-| 1  | Mostrar perfis cadastrados                         |
-| 2  | Autorizar todos perfis (e sincronizar com Rep4Rep) |
-| 3  | Executar comentários automáticos (autoRun)         |
-| 4  | Adicionar perfis do arquivo `accounts.txt`         |
-| 5  | Adicionar perfis e rodar imediatamente             |
-| 6  | Remover perfil (precisa digitar username)          |
-| 7  | Verificar e sincronizar perfis                     |
-| 8  | Verificar disponibilidade de comentários           |
-| 9  | Verificar se cada perfil ainda está logado         |
-| 10 | Exportar perfis para CSV                           |
-| 11 | Limpar contas inválidas (baseado no log diário)    |
-| 12 | Estatísticas de uso dos perfis                     |
-| 13 | Resetar cookies dos perfis                         |
-| 14 | Criar backup do banco de dados                     |
-| 0  | Sair                                               |
+## 🔄 Fluxo de trabalho
+- **Uso próprio via terminal:** a CLI utiliza sempre a `REP4REP_KEY` do `.env`, garantindo prioridade às suas tarefas e funcionamento mesmo que não exista painel.
+- **Vendas e clientes:** o painel registra usuários com créditos, chave Rep4Rep própria e cuida do débito automático a cada comentário concluído.
+- **Agendador prioritário:** toda execução dispara primeiro o lote do proprietário (token do `.env` ou da conta admin) e, somente se não houver comentários pendentes, percorre clientes elegíveis.
 
----
+## 🖥️ Comandos da CLI
+| Nº  | Ação                                                            |
+|-----|-----------------------------------------------------------------|
+| 1   | Mostrar perfis cadastrados                                      |
+| 2   | Autorizar todos perfis (atualiza cookies)                       |
+| 3   | **Executar autoRun prioritário** (proprietário ➜ clientes)      |
+| 4   | Adicionar perfis do arquivo `accounts.txt`                      |
+| 5   | Adicionar perfis e rodar imediatamente                          |
+| 6   | Remover perfil                                                  |
+| 7   | Verificar e sincronizar perfis com Rep4Rep                      |
+| 8   | Verificar disponibilidade de comentários                        |
+| 9   | Verificar status/login das contas                               |
+| 10  | Exportar perfis para CSV                                        |
+| 11  | Limpar contas inválidas ou duplicadas em `accounts.txt`         |
+| 12  | Estatísticas de uso dos perfis                                  |
+| 13  | Resetar cookies                                                 |
+| 14  | Criar backup do banco                                           |
+| 15  | **Ciclo completo**: adiciona contas ➜ executa autoRun ➜ remove  |
+| 16  | Ativar modo vigia (loop automático em segundo plano)             |
+| 0   | Sair                                                            |
 
-## 🌐 Como funciona o painel web
+A opção 15 impõe automaticamente **100 contas** e **1000 comentários por conta** como teto, garantindo que execuções pontuais não ultrapassem o combinado com clientes.
 
-O painel fica em `web/server.js` e roda em `http://localhost:3000` (porta configurável via `PORT`). A raiz do site entrega o portal do cliente, enquanto o painel administrativo protegido por autenticação básica fica em `http://localhost:3000/admin`.
-O painel fica em `web/server.js` e roda em `http://localhost:3000` (porta configurável via `PORT`). Ele foi desenhado para que apenas o administrador tenha controles avançados, enquanto os clientes consomem créditos por meio de uma API segura.
+## 🛡️ Prioridade, limites e limpeza
+- Todas as execuções usam `MAX_COMMENTS_PER_RUN` saneado para 1000 comentários por conta no máximo.
+- O agendador corta a lista de contas para, no máximo, 100 perfis por lote ao atender clientes.
+- Clientes precisam ter perfis ativos no Rep4Rep antes da execução; o backend valida isso antes de iniciar.
+- Ao rodar tarefas para clientes (via painel ou API), os perfis usados são removidos automaticamente do Rep4Rep ao final para não expor suas contas proprietárias.
+- Um serviço interno cria um **backup automático** do banco a cada 3 dias (ou quando nenhum backup recente é encontrado). Admins ainda podem gerar backups manuais sempre que desejarem.
+- O modo vigia pode ser acionado pela CLI (opção 16) ou pelo painel admin para manter o bot em execução contínua no servidor respeitando o limite de 100 contas / 1000 comentários.
+
+## 🌐 Painel web
+O servidor Express roda em `http://localhost:3000` (ajustável via `PORT`). A rota raiz serve o portal do cliente; `/admin` abre o painel protegido por autenticação básica.
 
 ### Acesso do administrador
+1. Configure `PANEL_USERNAME` e `PANEL_PASSWORD` no `.env`.
+2. Cadastre um usuário com `role = admin` pelo painel e defina nele a chave Rep4Rep que deseja usar quando estiver logado no painel.
+3. Ao clicar em **Executar autoRun** o painel busca essa chave no banco, executa o lote prioritário e segue com a fila de clientes. A chave do `.env` permanece oculta para o navegador.
+4. O painel ainda traz estatísticas, criação de backups e histórico de logs em tempo real.
+5. O card **Modo VPS / Vigia** permite iniciar/parar o loop automático diretamente do painel e acompanha status, intervalo configurado e erros do ciclo.
+6. Clique em **Gerenciar** na tabela de clientes para abrir o editor lateral e ajustar dados completos (status, créditos, key, telefone, role) sem editar código.
 
-1. Garanta que `PANEL_USERNAME` e `PANEL_PASSWORD` estejam definidos no `.env`.
-2. Inicie o painel com `npm run painel` (ou `npm run dev` para rodar bot + painel juntos).
-3. Abra o navegador em `http://localhost:3000/admin` e faça login via autenticação básica.
-3. Abra o navegador em `http://localhost:3000` e faça login via autenticação básica.
-4. A área inicial oferece:
-   - botões para `autoRun`, geração de estatísticas e backup do banco;
-   - atualização ao vivo do resumo de contas (total, prontas, em cooldown, comentários nas últimas 24h);
-   - visualização dos logs em `/logs`.
+### Portal do cliente
+- Cadastro exige nome completo, username, email, senha (≥ 8 caracteres), data de nascimento, Discord ID, Rep4Rep ID e telefone/WhatsApp com DDI.
+- Após o registro o status fica `pending`. O administrador precisa ativar e conceder créditos antes de liberar o botão **Rodar tarefas**.
+- Clientes autenticados visualizam créditos, status, token de API e podem atualizar a própria chave Rep4Rep.
 
-### Portal do cliente e fluxo de login
+### Créditos e permissões
+- **1 crédito = 1 comentário confirmado.** Durante o autoRun, cada comentário chama o callback de débito.
+- Usuários `admin` têm créditos ilimitados mas ainda precisam cadastrar a própria chave Rep4Rep.
+- Quando os créditos chegam a zero a API retorna `HTTP 402` até que o administrador adicione mais saldo.
+- O administrador pode ajustar créditos, status e dados de qualquer usuário pelo painel ou via endpoints autenticados em `/admin/api`.
 
-- O endereço público `http://localhost:3000/` expõe um portal onde o cliente pode **se registrar** ou **entrar** com o email/username.
-- O formulário de cadastro exige: nome completo, username, email, senha (mínimo 8 caracteres), data de nascimento, Discord ID, Rep4Rep ID e telefone/WhatsApp com DDI. Email e Rep4Rep ID não podem ser duplicados.
-- Assim que o cadastro é enviado o status fica como `pending`. O administrador precisa ativar a conta (via painel) e adicionar créditos antes que o cliente possa rodar tarefas.
-- Após o login, o cliente visualiza créditos restantes, status da conta, seus identificadores e pode atualizar a própria chave Rep4Rep. O botão “Rodar tarefas” só é liberado quando a conta está ativa, existe uma key salva e o saldo é maior que zero.
+### Tradução automática do painel
+- O cabeçalho do painel inclui o botão 🌐 **Idioma** com um seletor discreto alimentado pelo Google Translate.
+- Estão disponíveis traduções instantâneas para português, inglês, espanhol, francês, italiano e alemão sem recarregar a página.
+- A interface do widget segue o tema escuro do painel e pode ser recolhida para não interferir no fluxo de trabalho.
 
-### Gerenciamento de clientes e créditos
+## 🔐 Armazenamento e segurança
+- Usuários e perfis ficam no SQLite (`steamprofiles.db`). Senhas são protegidas com PBKDF2 (sal + hash) e tokens API são UUIDs aleatórios.
+- O arquivo `data/users.json` é mantido apenas como **backup legado**: as senhas não aparecem ali por segurança. Após a migração todos os campos sensíveis permanecem somente no banco criptografado.
+- Logs de execução são gravados em `logs/YYYY-MM-DD.log` e podem ser revisados pelo painel.
 
-O cartão **Clientes e créditos** é exclusivo do administrador e permite:
+## 🌱 Variáveis de ambiente
+| Variável | Descrição |
+|----------|-----------|
+| `REP4REP_KEY` | Chave Rep4Rep usada pela CLI e como fallback do proprietário. |
+| `MAX_COMMENTS_PER_RUN` | Limite por conta (cortado automaticamente em 1000). |
+| `LOGIN_DELAY` / `COMMENT_DELAY` | Delays (ms) entre logins e comentários. |
+| `PANEL_USERNAME` / `PANEL_PASSWORD` | Credenciais do Basic Auth do painel. |
+| `PORT` | Porta HTTP do painel (padrão `3000`). |
+| `DATABASE_PATH` | Caminho alternativo para o `steamprofiles.db` (opcional). |
+| `KEEPALIVE_INTERVAL_MINUTES` | Intervalo (min) entre ciclos do modo vigia automático (mínimo 5). |
 
-- cadastrar um novo cliente com todos os campos obrigatórios (nome completo, username, email, senha provisória ≥8 caracteres, data de nascimento, Discord ID, Rep4Rep ID e telefone/WhatsApp), além da chave Rep4Rep opcional e créditos iniciais;
-- armazenar tudo na tabela `app_user` do `steamprofiles.db`, com senha protegida via PBKDF2 e `apiToken` gerado automaticamente;
-- ajustar créditos rapidamente com botões `-1`, `+1` e `+10`;
-- visualizar status (ativo/bloqueado/pendente), identificadores do cliente e se a chave Rep4Rep já foi definida.
+Outras variáveis herdadas do `env.example` continuam válidas (SMTP, Discord, etc.).
 
-Para compartilhar o `apiToken` com o cliente, basta pedir que ele faça login pelo portal ou consultar `GET /admin/api/users` autenticado no painel (`curl -u usuario:senha http://localhost:3000/admin/api/users`).
-
-Somente o administrador pode criar, editar ou adicionar créditos – os clientes não conseguem alterar seu saldo.
-
-### Fluxo de créditos e permissões
-
-- **1 crédito = 1 tarefa concluída (1 comentário)**. Durante o `autoRun`, cada comentário debitado chama o callback de consumo.
-- Quando os créditos chegam a `0`, o cliente perde acesso aos comandos pagos e recebe `HTTP 402` até que o administrador adicione mais créditos.
- - O administrador pode pausar um cliente marcando o status como `blocked` pelo endpoint `PATCH /admin/api/users/:id` ou editando diretamente a tabela `app_user`.
-- A chave Rep4Rep usada pelo cliente pode ser diferente da chave do administrador. O painel e a CLI continuam usando a key global definida no `.env`.
-- O bot via terminal (`npm run bot`) segue operando normalmente com a sua `REP4REP_KEY` e não consome os créditos dos clientes — ideal para o administrador continuar as tarefas internas.
-
-### API pública para clientes
-
-Os clientes usam apenas a rota `/api/user`, autenticando-se com o `id` e o `token` obtidos após o login. Exemplo de fluxo completo usando `curl` e `jq`:
-
+## 🧰 Scripts disponíveis
 ```bash
-# registrar (status ficará pending até o administrador liberar créditos)
-curl -X POST http://localhost:3000/api/user/register \
-  -H "Content-Type: application/json" \
-  -d '{
-    "fullName": "João Cliente",
-    "username": "joaocliente",
-    "email": "joao@exemplo.com",
-    "password": "senhaSegura123",
-    "dateOfBirth": "1998-05-10",
-    "discordId": "joao#1234",
-    "rep4repId": "joao-rep",
-    "phoneNumber": "+351900000000"
-  }'
-
-# login para obter token e id
-login=$(curl -s -X POST http://localhost:3000/api/user/login \
-  -H "Content-Type: application/json" \
-  -d '{"identifier":"joao@exemplo.com","password":"senhaSegura123"}')
-token=$(echo "$login" | jq -r '.token')
-user_id=$(echo "$login" | jq -r '.user.id')
-
-# consultar perfil autenticado
-curl -X GET http://localhost:3000/api/user/me \
-  -H "x-user-id: $user_id" \
-  -H "Authorization: Bearer $token"
-- cadastrar um novo cliente com nome, email, chave Rep4Rep e créditos iniciais;
-- ajustar créditos rapidamente com botões `-1`, `+1` e `+10`;
-- visualizar status (ativo/bloqueado/pendente) e se a chave Rep4Rep já foi definida.
-
-Cada cliente recebe automaticamente um `apiToken`. Para compartilhá-lo com o usuário final você pode:
-
-- abrir `data/users.json` e copiar os campos `id` e `apiToken`; ou
-- chamar `GET /api/admin/users` autenticado no painel (ex.: via `curl -u admin:senha http://localhost:3000/api/admin/users`).
-
-Somente o administrador pode criar, editar ou adicionar créditos – os clientes não conseguem alterar seu saldo.
-
-### Fluxo de créditos e permissões
-
-- **1 crédito = 1 tarefa concluída (1 comentário)**. Durante o `autoRun`, cada comentário debitado chama o callback de consumo.
-- Quando os créditos chegam a `0`, o cliente perde acesso aos comandos pagos e recebe `HTTP 402` até que o administrador adicione mais créditos.
-- O administrador pode pausar um cliente marcando o status como `blocked` (via edição direta no `data/users.json` ou endpoint futuro).
-- A chave Rep4Rep usada pelo cliente pode ser diferente da chave do administrador. O painel e a CLI continuam usando a key global definida no `.env`.
-
-### API pública para clientes
-
-Os clientes usam apenas a rota `/api/user`, autenticando-se com cabeçalhos ou parâmetros. Exemplo com `curl`:
-
-```bash
-curl -X GET http://localhost:3000/api/user/me \
-  -H "x-user-id: <ID_FORNECIDO>" \
-  -H "x-user-token: <API_TOKEN>"
+npm run bot     # Inicia apenas a CLI
+npm run painel  # Inicia apenas o painel web (web/server.js)
+npm run dev     # Executa CLI + painel simultaneamente
+install-bot.bat # (Windows) prepara .env e instala dependências
+start-bot.bat   # (Windows) inicia CLI e/ou painel com menu interativo
 ```
 
-Endpoints disponíveis:
+## 💡 Dicas e suporte
+- Execute periodicamente a opção 14 (backup) antes de atualizar o projeto.
+- Utilize a opção 11 para manter `accounts.txt` limpo e evitar contas duplicadas.
+- Para vender execuções automáticas exponha apenas a API `/api/user` e mantenha o painel protegido por VPN/Basic Auth.
+- Dúvidas adicionais? Consulte os logs (`npm run painel` ➜ `/admin/logs`) ou edite `src/util.cjs` para habilitar mais mensagens.
 
-- `POST /api/user/register` — cria o cadastro com status `pending` e retorna `id` + `status`.
-- `POST /api/user/login` — valida as credenciais e devolve `token` + dados do usuário.
-- `GET /api/user/me` — retorna dados básicos, status e créditos restantes.
-- `PATCH /api/user/me` — atualiza a chave Rep4Rep (`{ "rep4repKey": "..." }`).
-- `GET /api/user/me` — retorna dados básicos, status e créditos restantes.
-- `POST /api/user/run` — executa comandos seguros. Corpo esperado:
-
-  ```json
-  { "command": "autoRun" }
-  ```
-
-  Comandos suportados: `autoRun` (consome créditos) e `stats` (somente leitura).
-  Comando suportados: `autoRun` (consome créditos) e `stats` (somente leitura).
-
-Regras importantes:
-
-- Antes de rodar `autoRun`, o cliente precisa informar a própria `rep4repKey` via painel/admin.
-- O bot utiliza a key do cliente durante a execução; quando o limite de créditos é alcançado o processo é interrompido automaticamente.
-- Se os créditos acabarem no meio do processo, o retorno será `HTTP 402` e nenhuma tarefa adicional será iniciada.
-
----
-
-## 🗃️ Banco de dados e armazenamento
-
-- Toda a persistência fica em `steamprofiles.db` (SQLite). Além das tabelas de perfis (`steamprofile`) e comentários (`comments`), agora existe a tabela `app_user` com os campos: `id`, `username`, `fullName`, `email`, `passwordHash`, `passwordSalt`, `dateOfBirth`, `discordId`, `rep4repId`, `phoneNumber`, `rep4repKey`, `credits`, `apiToken`, `role`, `status`, `lastLoginAt`, `createdAt` e `updatedAt`.
-- Senhas são armazenadas com PBKDF2 (`sha512`, 120k iterações) e cada usuário recebe um `apiToken` aleatório. Para inspecionar rapidamente use `sqlite3 steamprofiles.db 'SELECT username, credits, status FROM app_user;'`.
-- Caso exista um `data/users.json` legado, ele é importado automaticamente na primeira execução e renomeado para `users.json.bak`. Novos dados permanecem apenas no banco SQLite.
-- Backups criados via painel são salvos em `backups/` e exportações CSV dos perfis ficam em `data/exports/`.
-
----
-
-## ⚙️ Variáveis de ambiente
-
-```env
-# Token da API do Rep4Rep usado pelo administrador/CLI
-REP4REP_KEY=seu_token_api
-
-# Tempo entre logins e comentários (em ms)
-LOGIN_DELAY=30000
-COMMENT_DELAY=15000
-
-# Comentários máximos por perfil em cada autoRun
-MAX_COMMENTS_PER_RUN=10
-
-# Credenciais de acesso ao painel web
-PANEL_USERNAME=admin
-PANEL_PASSWORD=senha123
-
-# Porta opcional para o painel (padrão 3000)
-PORT=3000
-```
-
----
-
-## 📦 Scripts disponíveis
-
-| Comando        | Descrição                                 |
-|----------------|-------------------------------------------|
-| `npm run bot`     | Inicia apenas o bot (CLI)                 |
-| `npm run painel`  | Sobe somente o painel web                 |
-| `npm run dev`     | Roda painel e bot em paralelo             |
-| `npm start`       | Abre navegador, bot e painel de uma vez   |
-
-> **Dica:** mantenha `steamprofiles.db` e os arquivos em `backups/` fora do versionamento público, pois contêm senhas hash e tokens de acesso.
-
----
-
-## 🌍 Hospedagem e domínio personalizado
-
-1. **Servidor dedicado ou VPS** – Suba uma máquina Linux (Ubuntu/Debian) e instale Node.js 18+. Copie o projeto e configure o `.env`.
-2. **Process manager** – Use `pm2` ou `systemd` para manter os processos sempre ativos:
-   ```bash
-   pm2 start "npm run bot" --name rep4rep-bot
-   pm2 start "npm run painel" --name rep4rep-painel
-   pm2 save
-   ```
-3. **DNS no GoDaddy/Namecheap** – Crie um registro `A` apontando o domínio para o IP do servidor. Após a propagação, configure um proxy (ex.: Nginx) redirecionando para `localhost:3000`:
-   ```nginx
-   server {
-     server_name painel.seudominio.com;
-     location / {
-       proxy_pass http://127.0.0.1:3000;
-       proxy_set_header Host $host;
-       proxy_set_header X-Real-IP $remote_addr;
-       proxy_set_header X-Forwarded-Proto $scheme;
-     }
-   }
-   ```
-4. **HTTPS automático** – Execute `certbot --nginx -d painel.seudominio.com` (ou use Caddy) para gerar certificados TLS gratuitos.
-5. **Segurança extra** – Configure firewall liberando apenas portas 80/443, mantenha `PANEL_USERNAME`/`PANEL_PASSWORD` fortes e realize backups periódicos com o botão do painel ou via `sqlite3`.
-
-> Dica: você pode mapear o portal do cliente em `painel.seudominio.com` e proteger a rota `/admin` com Basic Auth e IP restrito no Nginx para aumentar a segurança.
-
-| Comando        | Descrição                                 |
-|----------------|-------------------------------------------|
-| `npm run bot`     | Inicia apenas o bot (CLI)                 |
-| `npm run painel`  | Sobe somente o painel web                 |
-| `npm run dev`     | Roda painel e bot em paralelo             |
-| `npm start`       | Abre navegador, bot e painel de uma vez   |
-
-> **Dica:** mantenha `data/users.json` fora do versionamento público ao lidar com dados reais (contém tokens e emails).
-
----
-
-## 🆘 Suporte
-
-Se algo não funcionar:
-
-- confira as variáveis no `.env`;
-- valide o formato do `accounts.txt`;
-- consulte os logs mais recentes em `logs/` ou pelo painel (`/logs`).
-
----
-
-## ✨ Ideias futuras
-
-- Integração com Telegram para alertas em tempo real
-- Portal completo para o cliente acompanhar pedidos
-- Exportação detalhada de histórico de comentários

--- a/install-bot.bat
+++ b/install-bot.bat
@@ -1,0 +1,44 @@
+@echo off
+color 0b
+title Rep4Rep Bot - Instalador
+
+cls
+echo =============================================
+echo   Instalador Rep4Rep Bot
+echo =============================================
+echo.
+echo 1^) Instalar em PC local
+echo 2^) Instalar em VPS/Servidor
+set /p opt=Escolhe uma opcao [1-2]: 
+if "%opt%"=="1" goto INSTALL
+if "%opt%"=="2" goto INSTALL
+echo Opcao invalida.
+pause
+exit /b 1
+
+:INSTALL
+echo.
+echo [1/3] Preparando arquivo .env...
+if not exist .env (
+    copy env.example .env >nul
+)
+echo [2/3] Instalando dependencias do bot...
+call npm install
+if errorlevel 1 goto ERROR
+
+echo [3/3] Instalando dependencias do painel...
+pushd web
+call npm install
+if errorlevel 1 goto ERROR
+popd
+
+echo.
+echo Instalacao concluida! Ajuste o arquivo .env antes de iniciar o bot.
+pause
+exit /b 0
+
+:ERROR
+echo.
+echo Ocorreu um erro durante a instalacao. Verifique as mensagens acima.
+pause
+exit /b 1

--- a/src/util.cjs
+++ b/src/util.cjs
@@ -10,24 +10,51 @@ const db = require('./db.cjs');
 const api = require('./api.cjs');
 const { ApiError } = require('./api.cjs');
 const createSteamBot = require('./steamBot.cjs');
+const userStore = require('../web/services/userStore');
 
 const ROOT_DIR = path.join(__dirname, '..');
 const DATA_DIR = path.join(ROOT_DIR, 'data');
 const ACCOUNTS_PATH = path.join(ROOT_DIR, 'accounts.txt');
 const LOGS_DIR = path.join(ROOT_DIR, 'logs');
 const BACKUPS_DIR = path.join(ROOT_DIR, 'backups');
+const MAINTENANCE_STATE_FILE = path.join(DATA_DIR, 'maintenance-state.json');
 const EXPORTS_DIR = path.join(DATA_DIR, 'exports');
 
 const DEFAULT_LOGIN_DELAY = 30_000;
 const DEFAULT_COMMENT_DELAY = 15_000;
-const MAX_COMMENTS_PER_RUN = sanitizePositiveInteger(
+const configuredMaxComments = sanitizePositiveInteger(
   process.env.MAX_COMMENTS_PER_RUN ??
     process.env.COMMENT_LIMIT ??
     process.env.MAX_COMMENTS,
   10,
 );
+const MAX_COMMENTS_PER_RUN = Math.min(1000, configuredMaxComments);
+const KEEPALIVE_INTERVAL_MINUTES = Math.max(5, sanitizePositiveInteger(
+  process.env.KEEPALIVE_INTERVAL_MINUTES,
+  15,
+));
+const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000;
+const BACKUP_CHECK_INTERVAL_MS = 12 * 60 * 60 * 1000;
 
 let rl = null;
+
+const maintenanceState = {
+  backupTimer: null,
+  initialized: false,
+  lastAutomaticBackup: null,
+};
+
+const keepAliveState = {
+  running: false,
+  stopRequested: false,
+  promise: null,
+  intervalMs: KEEPALIVE_INTERVAL_MINUTES * 60 * 1000,
+  lastRunAt: null,
+  startedAt: null,
+  lastError: null,
+  runs: 0,
+  ownerToken: null,
+};
 
 const statusMessage = {
   inactive: 0,
@@ -77,6 +104,96 @@ function logInvalidAccount(username, reason) {
   const timestamp = new Date().toLocaleTimeString();
   const line = `[${timestamp}] ${username} - ${reason}\n`;
   fs.appendFileSync(logFile, line);
+}
+
+function readMaintenanceMetadata() {
+  try {
+    const raw = fs.readFileSync(MAINTENANCE_STATE_FILE, 'utf8');
+    const data = JSON.parse(raw);
+    if (!data || typeof data !== 'object') {
+      return {};
+    }
+    return data;
+  } catch (error) {
+    return {};
+  }
+}
+
+function writeMaintenanceMetadata(data) {
+  try {
+    ensureDirectory(path.dirname(MAINTENANCE_STATE_FILE));
+    fs.writeFileSync(MAINTENANCE_STATE_FILE, JSON.stringify(data, null, 2));
+  } catch (error) {
+    log(`⚠️ Não foi possível salvar metadados de manutenção: ${error.message}`);
+  }
+}
+
+function getLatestBackupTimestamp() {
+  if (!fs.existsSync(BACKUPS_DIR)) {
+    return 0;
+  }
+
+  const files = fs
+    .readdirSync(BACKUPS_DIR)
+    .filter((file) => file.toLowerCase().endsWith('.sqlite'));
+
+  let latest = 0;
+  for (const file of files) {
+    try {
+      const stats = fs.statSync(path.join(BACKUPS_DIR, file));
+      latest = Math.max(latest, stats.mtimeMs, stats.ctimeMs ?? 0);
+    } catch (error) {
+      log(`⚠️ Não foi possível ler data do backup ${file}: ${error.message}`);
+    }
+  }
+  return latest;
+}
+
+async function ensureAutomaticBackup() {
+  const metadata = readMaintenanceMetadata();
+  const recorded = metadata.lastAutomaticBackup
+    ? new Date(metadata.lastAutomaticBackup).getTime()
+    : 0;
+  const latestFile = getLatestBackupTimestamp();
+  const lastBackup = Math.max(recorded || 0, latestFile || 0);
+  const now = Date.now();
+
+  if (lastBackup && now - lastBackup < THREE_DAYS_MS) {
+    return null;
+  }
+
+  log('🗂️ Executando backup automático programado...');
+  const filePath = await backupDatabase();
+  if (filePath) {
+    metadata.lastAutomaticBackup = new Date().toISOString();
+    writeMaintenanceMetadata(metadata);
+    maintenanceState.lastAutomaticBackup = metadata.lastAutomaticBackup;
+  }
+  return filePath;
+}
+
+function scheduleAutomaticBackups() {
+  if (maintenanceState.initialized) {
+    return;
+  }
+  maintenanceState.initialized = true;
+
+  ensureDirectory(path.dirname(MAINTENANCE_STATE_FILE));
+  const metadata = readMaintenanceMetadata();
+  if (metadata.lastAutomaticBackup) {
+    maintenanceState.lastAutomaticBackup = metadata.lastAutomaticBackup;
+  }
+
+  const run = () => {
+    ensureAutomaticBackup().catch((error) => {
+      log(`⚠️ Backup automático falhou: ${error.message}`);
+    });
+  };
+
+  // Executa verificação logo no início, mas sem bloquear a inicialização.
+  setTimeout(run, 5_000);
+
+  maintenanceState.backupTimer = setInterval(run, BACKUP_CHECK_INTERVAL_MS);
 }
 
 function removeFromAccountsFile(username) {
@@ -291,6 +408,37 @@ async function removeFromRep4Rep(steamId, options = {}) {
   }
 }
 
+function extractSteamIdsFromSummary(summary) {
+  if (!summary || !Array.isArray(summary.perAccount)) {
+    return [];
+  }
+
+  const ids = summary.perAccount
+    .map((item) => (item && item.steamId ? String(item.steamId) : null))
+    .filter(Boolean);
+  return [...new Set(ids)];
+}
+
+async function removeRemoteProfiles(summary, options = {}) {
+  const { apiClient = api, apiToken = null } = options;
+  const steamIds = extractSteamIdsFromSummary(summary);
+  if (!steamIds.length) {
+    return { attempted: 0, removed: 0 };
+  }
+
+  let removed = 0;
+  for (const steamId of steamIds) {
+    try {
+      await apiClient.removeSteamProfile(steamId, { token: apiToken });
+      removed += 1;
+    } catch (error) {
+      log(`[Rep4Rep] Falha ao remover ${steamId} após execução: ${describeApiError(error)}`);
+    }
+  }
+
+  return { attempted: steamIds.length, removed };
+}
+
 async function showAllProfiles() {
   const profiles = await db.getAllProfiles();
   if (!profiles.length) {
@@ -317,12 +465,21 @@ async function addProfilesFromFile(options = {}) {
     return { added: 0, total: 0 };
   }
 
+  const limit = Number.isFinite(options.limitAccounts)
+    ? Math.max(1, Math.floor(options.limitAccounts))
+    : null;
+  const selectedAccounts = limit ? accounts.slice(0, limit) : accounts;
+  if (!selectedAccounts.length) {
+    log('Nenhuma conta disponível após aplicar o limite configurado.');
+    return { added: 0, total: 0 };
+  }
+
   const existingProfiles = await db.getAllProfiles();
   const knownUsers = new Set(existingProfiles.map((profile) => profile.username));
 
   let added = 0;
 
-  for (const line of accounts) {
+  for (const line of selectedAccounts) {
     let account;
     try {
       account = parseAccountLine(line);
@@ -374,12 +531,46 @@ async function addProfilesFromFile(options = {}) {
   }
 
   log(`Processo concluído. ${added} novo(s) perfil(is) adicionados.`);
-  return { added, total: accounts.length };
+  return { added, total: selectedAccounts.length };
 }
 
 async function addProfilesAndRun(options = {}) {
   await addProfilesFromFile(options);
   return autoRun(options);
+}
+
+async function runFullCycle(options = {}) {
+  const maxAccounts = Number.isFinite(options.maxAccounts)
+    ? Math.min(100, Math.max(1, Math.floor(options.maxAccounts)))
+    : 100;
+  const maxComments = Math.min(
+    1000,
+    Math.max(1, options.maxCommentsPerAccount ?? MAX_COMMENTS_PER_RUN),
+  );
+  const apiClient = options.apiClient || api;
+  const apiToken = options.apiToken ?? null;
+
+  log(
+    `Iniciando fluxo completo com até ${maxAccounts} contas e ${maxComments} comentários por conta.`,
+  );
+
+  const addResult = await addProfilesFromFile({
+    ...options,
+    limitAccounts: maxAccounts,
+    apiClient,
+    apiToken,
+  });
+
+  const summary = await autoRun({
+    ...options,
+    apiClient,
+    apiToken,
+    maxCommentsPerAccount: maxComments,
+    accountLimit: maxAccounts,
+  });
+
+  const cleanup = await removeRemoteProfiles(summary, { apiClient, apiToken });
+  return { addResult, summary, cleanup };
 }
 
 function resolveRemoteProfileId(remoteProfile) {
@@ -492,11 +683,20 @@ async function autoRun(options = {}) {
     loginDelay = sanitizeDelay(process.env.LOGIN_DELAY, DEFAULT_LOGIN_DELAY),
     onTaskComplete,
     filterProfiles,
+    accountLimit = null,
+    onFinish,
   } = options;
 
   const accounts = readAccountsFile();
   if (!accounts.length) {
     log('Nenhuma conta configurada no accounts.txt. Adicione contas antes de executar o autoRun.', true);
+    return { totalComments: 0, perAccount: [] };
+  }
+
+  const limit = Number.isFinite(accountLimit) ? Math.max(1, Math.floor(accountLimit)) : null;
+  const selectedAccounts = limit ? accounts.slice(0, limit) : accounts;
+  if (!selectedAccounts.length) {
+    log('Nenhuma conta disponível para execução após aplicar o limite configurado.', true);
     return { totalComments: 0, perAccount: [] };
   }
 
@@ -524,7 +724,7 @@ async function autoRun(options = {}) {
   const remoteMap = new Map(remoteProfiles.map((remote) => [String(remote.steamId), remote]));
   const summary = { totalComments: 0, perAccount: [] };
 
-  for (const [index, accountLine] of accounts.entries()) {
+  for (const [index, accountLine] of selectedAccounts.entries()) {
     let account;
     try {
       account = parseAccountLine(accountLine);
@@ -636,12 +836,19 @@ async function autoRun(options = {}) {
       break;
     }
 
-    if (index < accounts.length - 1) {
+    if (index < selectedAccounts.length - 1) {
       await sleep(loginDelay);
     }
   }
 
   log(`✅ autoRun concluído. Total de comentários enviados: ${summary.totalComments}`);
+  if (typeof onFinish === 'function') {
+    try {
+      await onFinish(summary);
+    } catch (error) {
+      log(`⚠️ Callback onFinish falhou: ${error.message}`);
+    }
+  }
   return summary;
 }
 
@@ -698,6 +905,254 @@ async function removeProfile(username, options = {}) {
   await db.removeProfile(user);
   removeFromAccountsFile(user);
   log(`[${user}] Removido do sistema.`);
+}
+
+async function prioritizedAutoRun(options = {}) {
+  const {
+    ownerToken = process.env.REP4REP_KEY ?? null,
+    maxCommentsPerAccount = MAX_COMMENTS_PER_RUN,
+    accountLimit = 100,
+    clientFilter,
+    onClientProcessed,
+    ...runOverrides
+  } = options;
+
+  const maxComments = Math.min(1000, Math.max(1, maxCommentsPerAccount));
+  const baseRunOptions = {
+    ...runOverrides,
+    maxCommentsPerAccount: maxComments,
+    accountLimit,
+  };
+
+  const result = { owner: null, clients: [] };
+
+  if (ownerToken) {
+    log('🚀 Executando lote prioritário do proprietário...');
+    try {
+      const summary = await autoRun({ ...baseRunOptions, apiToken: ownerToken });
+      result.owner = summary;
+      if (summary.totalComments > 0) {
+        log('Pedidos do proprietário atendidos. Clientes serão processados posteriormente.');
+        return result;
+      }
+    } catch (error) {
+      log(`❌ Falha ao executar autoRun prioritário: ${error.message}`);
+    }
+  } else {
+    log('⚠️ Nenhum token do proprietário configurado. Pulando etapa prioritária.');
+  }
+
+  let users = [];
+  try {
+    users = await userStore.listUsers();
+  } catch (error) {
+    log(`❌ Falha ao carregar usuários para fila de clientes: ${error.message}`);
+    return result;
+  }
+
+  const eligibleClients = users.filter((user) => {
+    if (typeof clientFilter === 'function' && !clientFilter(user)) {
+      return false;
+    }
+    if (!user.rep4repKey) {
+      return false;
+    }
+    if (user.status !== 'active') {
+      return false;
+    }
+    if (user.role === 'admin') {
+      return true;
+    }
+    return user.credits > 0;
+  });
+
+  for (const client of eligibleClients) {
+    const isAdmin = client.role === 'admin';
+    const creditLimit = isAdmin ? Infinity : client.credits;
+    let usedCredits = 0;
+
+    log(`🧾 Processando cliente ${client.username} (${client.id}).`);
+    try {
+      const summary = await autoRun({
+        ...baseRunOptions,
+        apiToken: client.rep4repKey,
+        onTaskComplete: () => {
+          if (isAdmin) {
+            return true;
+          }
+          usedCredits += 1;
+          return usedCredits < creditLimit;
+        },
+      });
+
+      const consumed = isAdmin
+        ? summary.totalComments
+        : Math.min(summary.totalComments ?? usedCredits, creditLimit);
+
+      if (!isAdmin && consumed > 0) {
+        try {
+          await userStore.consumeCredits(client.id, consumed);
+        } catch (creditError) {
+          log(`⚠️ Falha ao debitar créditos de ${client.username}: ${creditError.message}`);
+        }
+      }
+
+      const cleanup = await removeRemoteProfiles(summary, {
+        apiToken: client.rep4repKey,
+        apiClient: baseRunOptions.apiClient || api,
+      });
+
+      const clientResult = { client, summary, creditsConsumed: isAdmin ? 0 : consumed, cleanup };
+      result.clients.push(clientResult);
+      if (typeof onClientProcessed === 'function') {
+        try {
+          await onClientProcessed(clientResult);
+        } catch (callbackError) {
+          log(`⚠️ onClientProcessed falhou: ${callbackError.message}`);
+        }
+      }
+
+      if (summary.totalComments > 0) {
+        log(`✅ Execução concluída para ${client.username}.`);
+        break;
+      }
+    } catch (error) {
+      log(`❌ Falha ao processar ${client.username}: ${error.message}`);
+    }
+  }
+
+  if (!result.clients.length) {
+    log('Nenhum cliente elegível para processamento neste ciclo.');
+  }
+
+  return result;
+}
+
+async function waitWithAbort(totalMs, state = keepAliveState) {
+  let remaining = Math.max(0, Number(totalMs) || 0);
+  const step = Math.min(60_000, Math.max(1_000, remaining));
+  while (!state.stopRequested && remaining > 0) {
+    const chunk = Math.min(step, remaining);
+    await sleep(chunk);
+    remaining -= chunk;
+  }
+}
+
+async function startKeepAliveLoop(options = {}) {
+  if (keepAliveState.running) {
+    return { alreadyRunning: true, status: getKeepAliveStatus() };
+  }
+
+  const intervalMinutes = Math.max(
+    5,
+    sanitizePositiveInteger(options.intervalMinutes, KEEPALIVE_INTERVAL_MINUTES),
+  );
+  keepAliveState.intervalMs = intervalMinutes * 60 * 1000;
+  keepAliveState.stopRequested = false;
+  keepAliveState.running = true;
+  keepAliveState.startedAt = new Date().toISOString();
+  keepAliveState.lastError = null;
+  keepAliveState.runs = 0;
+  keepAliveState.ownerToken = options.ownerToken || process.env.REP4REP_KEY || null;
+
+  const runOptions = {
+    accountLimit: 100,
+    maxCommentsPerAccount: MAX_COMMENTS_PER_RUN,
+    ...options.runOptions,
+  };
+
+  const loop = async () => {
+    while (!keepAliveState.stopRequested) {
+      try {
+        const summary = await prioritizedAutoRun({
+          ...runOptions,
+          ownerToken: keepAliveState.ownerToken || runOptions.ownerToken,
+        });
+        keepAliveState.lastRunAt = new Date().toISOString();
+        keepAliveState.runs += 1;
+        keepAliveState.lastError = null;
+        keepAliveState.lastSummary = {
+          totalComments: summary?.owner?.totalComments ?? summary?.totalComments ?? 0,
+          timestamp: keepAliveState.lastRunAt,
+        };
+      } catch (error) {
+        keepAliveState.lastRunAt = new Date().toISOString();
+        keepAliveState.lastError = error.message;
+        log(`⚠️ Vigia automático falhou: ${error.message}`);
+      }
+
+      if (keepAliveState.stopRequested) {
+        break;
+      }
+
+      await waitWithAbort(keepAliveState.intervalMs);
+    }
+
+    keepAliveState.running = false;
+    keepAliveState.promise = null;
+  };
+
+  keepAliveState.promise = loop();
+  return { started: true, status: getKeepAliveStatus() };
+}
+
+async function stopKeepAliveLoop() {
+  if (!keepAliveState.running) {
+    return { stopped: false, status: getKeepAliveStatus() };
+  }
+
+  keepAliveState.stopRequested = true;
+  if (keepAliveState.promise) {
+    try {
+      await keepAliveState.promise;
+    } catch (error) {
+      log(`⚠️ Erro ao encerrar vigia: ${error.message}`);
+    }
+  }
+
+  keepAliveState.running = false;
+  keepAliveState.promise = null;
+  return { stopped: true, status: getKeepAliveStatus() };
+}
+
+function getKeepAliveStatus() {
+  return {
+    running: keepAliveState.running,
+    intervalMinutes: Math.round((keepAliveState.intervalMs / 60_000) * 10) / 10,
+    startedAt: keepAliveState.startedAt,
+    lastRunAt: keepAliveState.lastRunAt,
+    runs: keepAliveState.runs,
+    lastError: keepAliveState.lastError,
+    ownerTokenDefined: Boolean(keepAliveState.ownerToken),
+  };
+}
+
+async function keepBotAliveInteractive(options = {}) {
+  const { alreadyRunning } = await startKeepAliveLoop(options);
+  if (alreadyRunning) {
+    log('⚠️ O modo vigia já está ativo em segundo plano.');
+    return getKeepAliveStatus();
+  }
+
+  log(
+    `🛡️ Modo vigia ativo. Executando prioridade a cada ${Math.round(
+      keepAliveState.intervalMs / 60_000,
+    )} minuto(s). Pressione Ctrl+C para encerrar.`,
+  );
+
+  return new Promise((resolve) => {
+    const finish = async () => {
+      log('⏹️ Encerrando modo vigia. Aguardando ciclo atual...');
+      await stopKeepAliveLoop();
+      process.off('SIGINT', finish);
+      process.off('SIGTERM', finish);
+      log('✅ Modo vigia encerrado.');
+      resolve(getKeepAliveStatus());
+    };
+
+    process.once('SIGINT', finish);
+    process.once('SIGTERM', finish);
+  });
 }
 
 async function checkAndSyncProfiles(options = {}) {
@@ -938,6 +1393,7 @@ module.exports = {
   logInvalidAccount,
   removeFromAccountsFile,
   removeFromRep4Rep,
+  removeRemoteProfiles,
   loginWithRetries,
   statusMessage,
   showAllProfiles,
@@ -947,6 +1403,8 @@ module.exports = {
   autoRun,
   addProfilesFromFile,
   addProfilesAndRun,
+  runFullCycle,
+  prioritizedAutoRun,
   checkAndSyncProfiles,
   checkCommentAvailability,
   verifyProfileStatus,
@@ -956,6 +1414,11 @@ module.exports = {
   collectUsageStats,
   resetProfileCookies,
   backupDatabase,
+  scheduleAutomaticBackups,
+  startKeepAliveLoop,
+  stopKeepAliveLoop,
+  getKeepAliveStatus,
+  keepBotAliveInteractive,
   describeApiError,
   readAccountsFile,
   parseStoredCookies,

--- a/start-bot.bat
+++ b/start-bot.bat
@@ -1,0 +1,43 @@
+@echo off
+color 0b
+title Rep4Rep Bot - Inicializador
+
+:MENU
+cls
+echo =============================================
+echo   Iniciar Rep4Rep Bot
+echo =============================================
+echo.
+echo 1^) Apenas terminal (CLI)
+echo 2^) Terminal + Painel (abre navegador)
+echo 3^) Terminal + Painel (sem abrir navegador)
+echo 4^) Sair
+set /p opt=Escolhe uma opcao [1-4]: 
+if "%opt%"=="1" goto CLI
+if "%opt%"=="2" goto BOTH
+if "%opt%"=="3" goto BOTH_HEADLESS
+if "%opt%"=="4" exit /b 0
+echo Opcao invalida.
+pause
+goto MENU
+
+:CLI
+cls
+echo Iniciando apenas a CLI...
+call node main.cjs
+pause
+goto MENU
+
+:BOTH
+cls
+echo Iniciando CLI + Painel...
+call node start.js
+pause
+goto MENU
+
+:BOTH_HEADLESS
+cls
+echo Iniciando CLI + Painel (sem abrir navegador)...
+call node start.js --no-browser
+pause
+goto MENU

--- a/start.js
+++ b/start.js
@@ -1,22 +1,44 @@
-// start.js
 const { fork } = require('child_process');
-const open = require('open');
 const path = require('path');
+const minimist = require('minimist');
 
-// Caminhos relativos
+const open = require('open');
+
+const args = minimist(process.argv.slice(2), {
+  boolean: ['no-browser', 'nobrowser', 'noBrowser'],
+  alias: {
+    headless: 'no-browser',
+  },
+});
+
+const shouldOpenBrowser = !(
+  args['no-browser'] || args.nobrowser || args.noBrowser || args.headless
+);
+
 const botPath = path.join(__dirname, 'main.cjs');
 const panelPath = path.join(__dirname, 'web', 'server.js');
 
-// Inicia o bot
 console.log('[🔁] Iniciando BOT...');
-fork(botPath);
+const botProcess = fork(botPath, { stdio: 'inherit' });
 
-// Inicia o painel
 console.log('[🌐] Iniciando Painel Web...');
-fork(panelPath);
+const panelProcess = fork(panelPath, { stdio: 'inherit' });
 
-// Aguarda e abre o navegador
-setTimeout(() => {
+const shutdown = () => {
+  console.log('\n[⏹️] Encerrando processos filhos...');
+  botProcess.kill();
+  panelProcess.kill();
+  process.exit(0);
+};
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+
+if (shouldOpenBrowser) {
+  setTimeout(() => {
     console.log('[🚀] Abrindo navegador...');
-    open('http://localhost:3000'); // ou a porta que usares
-}, 2000); // Espera 2s para garantir que o painel já está subindo
+    open(`http://localhost:${process.env.PORT || 3000}`);
+  }, 2000);
+} else {
+  console.log('[ℹ️] Painel disponível em http://localhost:%s (sem abrir navegador automático).', process.env.PORT || 3000);
+}

--- a/web/public/style.css
+++ b/web/public/style.css
@@ -51,6 +51,12 @@ a {
   box-shadow: 0 20px 45px -30px rgba(8, 145, 178, 0.8);
 }
 
+.app-header__right {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
 .brand {
   display: flex;
   align-items: center;
@@ -85,6 +91,79 @@ a {
   display: flex;
   gap: 14px;
 }
+
+.language-switch {
+  position: relative;
+}
+
+.language-switch > .btn {
+  gap: 6px;
+  font-size: 0.9rem;
+  padding: 10px 14px;
+}
+
+.language-switch__dropdown {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  min-width: 220px;
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 14px;
+  padding: 16px;
+  box-shadow: 0 18px 40px -24px rgba(56, 189, 248, 0.65);
+  backdrop-filter: blur(12px);
+  z-index: 50;
+}
+
+.language-switch__dropdown[hidden] {
+  display: none;
+}
+
+.language-switch__widget {
+  margin-bottom: 12px;
+}
+
+.language-switch__hint {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.language-switch__dropdown .goog-te-gadget {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  font-family: inherit;
+}
+
+.language-switch__dropdown .goog-te-combo {
+  width: 100%;
+  background: rgba(30, 41, 59, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 10px;
+  color: var(--text);
+  padding: 8px 12px;
+  font-size: 0.9rem;
+  appearance: none;
+}
+
+.language-switch__dropdown .goog-te-combo:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.25);
+}
+
+.language-switch__dropdown .goog-logo-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.language-switch__dropdown .goog-logo-link img {
+  filter: grayscale(1) brightness(1.2);
+}
+
 
 .app-nav__link {
   text-decoration: none;
@@ -159,6 +238,36 @@ a {
   flex-wrap: wrap;
   gap: 12px;
   margin: 16px 0;
+}
+
+.watchdog-banner {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  background: rgba(14, 165, 233, 0.08);
+  color: var(--text-muted);
+  margin-bottom: 12px;
+}
+
+.watchdog-banner__state {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.watchdog-banner__state[data-state='on'] {
+  color: var(--success);
+}
+
+.watchdog-banner__state[data-state='off'] {
+  color: var(--text-muted);
+}
+
+.watchdog-banner__info {
+  font-size: 0.8rem;
 }
 
 .hero__hint {
@@ -254,6 +363,62 @@ a {
   display: flex;
   flex-direction: column;
   gap: 18px;
+}
+
+.watchdog-card {
+  gap: 16px;
+}
+
+.watchdog-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+  margin: 0;
+}
+
+.watchdog-stats div {
+  background: rgba(14, 165, 233, 0.08);
+  border-radius: 14px;
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  padding: 14px 16px;
+}
+
+.watchdog-stats dt {
+  margin: 0 0 6px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.watchdog-stats dd {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.watchdog-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.watchdog-note {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.watchdog-note code {
+  background: rgba(148, 163, 184, 0.18);
+  padding: 2px 6px;
+  border-radius: 6px;
+}
+
+.watchdog-error {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--warning);
+  min-height: 1.2em;
 }
 
 .card__body--split {
@@ -532,6 +697,94 @@ a {
   pointer-events: auto;
 }
 
+.user-editor {
+  position: fixed;
+  inset: 0;
+  background: rgba(2, 6, 23, 0.72);
+  backdrop-filter: blur(10px);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 950;
+}
+
+.user-editor.is-visible {
+  display: flex;
+}
+
+.user-editor__container {
+  width: min(720px, 100%);
+  background: rgba(15, 23, 42, 0.95);
+  border-radius: 18px;
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  box-shadow: 0 30px 80px -40px rgba(8, 145, 178, 0.75);
+  display: flex;
+  flex-direction: column;
+  max-height: 90vh;
+}
+
+.user-editor__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.user-editor__header h3 {
+  margin: 0;
+}
+
+.user-editor__form {
+  padding: 20px 24px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  overflow-y: auto;
+}
+
+.user-editor__grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.user-editor__grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.user-editor__grid input,
+.user-editor__grid select {
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.85);
+  color: var(--text);
+  padding: 10px 12px;
+  font-family: inherit;
+}
+
+.user-editor__grid input:focus,
+.user-editor__grid select:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.55);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.2);
+}
+
+.user-editor__field--wide {
+  grid-column: 1 / -1;
+}
+
+.user-editor__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
 .logs-body {
   display: flex;
   flex-direction: column;
@@ -787,8 +1040,26 @@ a {
     gap: 16px;
   }
 
+  .app-header__right {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
   .app-nav {
     width: 100%;
+  }
+
+  .language-switch {
+    width: 100%;
+  }
+
+  .language-switch__dropdown {
+    position: static;
+    width: 100%;
+    margin-top: 0;
+    box-shadow: none;
   }
 
   .hero__content,

--- a/web/routes/user.js
+++ b/web/routes/user.js
@@ -2,7 +2,13 @@ const express = require('express');
 const router = express.Router();
 
 const userStore = require('../services/userStore');
-const { autoRun, collectUsageStats } = require('../../src/util.cjs');
+const {
+  autoRun,
+  collectUsageStats,
+  removeRemoteProfiles,
+  describeApiError,
+} = require('../../src/util.cjs');
+const rep4repApi = require('../../src/api.cjs');
 
 function extractAuth(req) {
   const authHeader = req.header('authorization');
@@ -78,7 +84,6 @@ router.use(async (req, res, next) => {
     const user = await userStore.authenticateUser({ userId, token });
     if (!user) {
       return res.status(401).json({ success: false, error: 'Credenciais inválidas ou conta inativa.' });
-      return res.status(401).json({ success: false, error: 'Credenciais inválidas.' });
     }
     req.user = user;
     next();
@@ -124,11 +129,6 @@ router.patch('/me', async (req, res) => {
   }
 });
 
-      rep4repKey: user.rep4repKey,
-    },
-  });
-});
-
 router.post('/run', async (req, res) => {
   const { command = 'autoRun' } = req.body || {};
   const allowedCommands = new Set(['autoRun', 'stats']);
@@ -145,11 +145,13 @@ router.post('/run', async (req, res) => {
     }
   }
 
+  const isAdmin = req.user.role === 'admin';
+
   if (req.user.status !== 'active') {
     return res.status(403).json({ success: false, error: 'Conta ainda não ativada. Aguarde a liberação pelo administrador.' });
   }
 
-  if (req.user.credits <= 0) {
+  if (!isAdmin && req.user.credits <= 0) {
     return res.status(402).json({ success: false, error: 'Créditos insuficientes.' });
   }
 
@@ -157,26 +159,49 @@ router.post('/run', async (req, res) => {
     return res.status(400).json({ success: false, error: 'Defina a chave Rep4Rep antes de executar comandos.' });
   }
 
-  const creditLimit = req.user.credits;
+  let remoteProfiles;
+  try {
+    remoteProfiles = await rep4repApi.getSteamProfiles({ token: req.user.rep4repKey });
+  } catch (error) {
+    return res.status(502).json({ success: false, error: describeApiError(error) });
+  }
+
+  if (!Array.isArray(remoteProfiles) || remoteProfiles.length === 0) {
+    return res.status(400).json({
+      success: false,
+      error: 'Nenhum perfil Rep4Rep encontrado. Adicione contas antes de executar o comando.',
+    });
+  }
+
+  const creditLimit = isAdmin ? Infinity : req.user.credits;
   let usedCredits = 0;
 
   try {
     const summary = await autoRun({
       apiToken: req.user.rep4repKey,
+      maxCommentsPerAccount: 1000,
+      accountLimit: 100,
       onTaskComplete: () => {
-        usedCredits += 1;
-        if (usedCredits >= creditLimit) {
-          return false;
+        if (isAdmin) {
+          return true;
         }
-        return true;
+        usedCredits += 1;
+        return usedCredits < creditLimit;
       },
     });
 
-    const consumed = Math.min(summary.totalComments ?? usedCredits, creditLimit);
+    const consumed = isAdmin
+      ? summary.totalComments ?? 0
+      : Math.min(summary.totalComments ?? usedCredits, creditLimit);
     let updatedUser = req.user;
-    if (consumed > 0) {
+    if (!isAdmin && consumed > 0) {
       updatedUser = await userStore.consumeCredits(req.user.id, consumed);
     }
+
+    const cleanup = await removeRemoteProfiles(summary, {
+      apiClient: rep4repApi,
+      apiToken: req.user.rep4repKey,
+    });
 
     res.json({
       success: true,
@@ -184,6 +209,7 @@ router.post('/run', async (req, res) => {
       summary,
       creditsConsumed: consumed,
       remainingCredits: updatedUser.credits,
+      cleanup,
     });
   } catch (error) {
     if (/Créditos insuficientes/.test(error.message)) {

--- a/web/server.js
+++ b/web/server.js
@@ -4,6 +4,7 @@ const path = require('path');
 const panelRouter = require('./routes/panel');
 const userRouter = require('./routes/user');
 const clientRouter = require('./routes/client');
+const { scheduleAutomaticBackups } = require('../src/util.cjs');
 const app = express();
 
 app.use(express.urlencoded({ extended: true }));
@@ -13,6 +14,7 @@ app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
 
 app.locals.siteName = 'Rep4Rep Control Center';
+scheduleAutomaticBackups();
 
 app.use('/api/user', userRouter);
 app.use('/admin', panelRouter);

--- a/web/services/userStore.js
+++ b/web/services/userStore.js
@@ -15,14 +15,11 @@ const PASSWORD_KEYLEN = 64;
 const PASSWORD_DIGEST = 'sha512';
 
 function generateApiToken() {
-  return randomUUID().replace(/-/g, '') + randomUUID().replace(/-/g, '');
+  return randomUUID().replace(/-/g, '');
 }
 
 function normalizeString(value) {
-  if (typeof value !== 'string') {
-    return '';
-  }
-  return value.trim();
+  return typeof value === 'string' ? value.trim() : '';
 }
 
 function normalizeEmail(email) {
@@ -84,95 +81,26 @@ async function verifyPassword(password, storedHash, storedSalt) {
   if (!storedHash || !storedSalt) {
     return false;
   }
-  try {
-    const derived = await pbkdf2Async(
-      normalizeString(password),
-      storedSalt,
-      PASSWORD_ITERATIONS,
-      PASSWORD_KEYLEN,
-      PASSWORD_DIGEST,
-    );
-    const derivedHex = derived.toString('hex');
-    return (
-      derivedHex.length === storedHash.length &&
-      timingSafeEqual(Buffer.from(derivedHex, 'hex'), Buffer.from(storedHash, 'hex'))
-    );
-function generateApiToken() {
-  return randomUUID().replace(/-/g, '');
-}
 
-async function ensureDataFile() {
-  await fs.mkdir(DATA_DIR, { recursive: true });
-  try {
-    await fs.access(USERS_FILE);
-  } catch (error) {
-    const now = new Date().toISOString();
-    const seed = [
-      {
-        id: 'demo-user',
-        displayName: 'Cliente Demo',
-        email: 'demo@example.com',
-        rep4repKey: '',
-        credits: 10,
-        status: 'active',
-        role: 'customer',
-        notes: 'Exemplo de usuário. Pode ser removido com segurança.',
-        apiToken: generateApiToken(),
-        createdAt: now,
-        updatedAt: now,
-      },
-    ];
-    await fs.writeFile(USERS_FILE, JSON.stringify(seed, null, 2), 'utf8');
-  }
-}
-
-async function readUsers() {
-  await ensureDataFile();
-  const raw = await fs.readFile(USERS_FILE, 'utf8');
-  try {
-    const data = JSON.parse(raw);
-    if (!Array.isArray(data)) {
-      return [];
-    }
-
-    let mutated = false;
-    const normalized = data.map((user) => {
-      const next = { ...user };
-      if (!next.id) {
-        next.id = randomUUID();
-        mutated = true;
-      }
-      if (!next.role) {
-        next.role = 'customer';
-        mutated = true;
-      }
-      if (!next.status) {
-        next.status = 'active';
-        mutated = true;
-      }
-      if (typeof next.credits !== 'number') {
-        next.credits = 0;
-        mutated = true;
-      }
-      if (!next.apiToken) {
-        next.apiToken = generateApiToken();
-        mutated = true;
-      }
-      return next;
-    });
-
-    if (mutated) {
-      await fs.writeFile(USERS_FILE, JSON.stringify(normalized, null, 2), 'utf8');
-    }
-
-    return normalized;
-  } catch (error) {
-    return false;
-  }
+  const derived = await pbkdf2Async(
+    normalizeString(password),
+    storedSalt,
+    PASSWORD_ITERATIONS,
+    PASSWORD_KEYLEN,
+    PASSWORD_DIGEST,
+  );
+  const derivedHex = derived.toString('hex');
+  return (
+    derivedHex.length === storedHash.length &&
+    timingSafeEqual(Buffer.from(derivedHex, 'hex'), Buffer.from(storedHash, 'hex'))
+  );
 }
 
 function sanitizeUser(row) {
-  if (!row) return null;
+  if (!row) {
+    return null;
+  }
+
   return {
     id: row.id,
     username: row.username,
@@ -205,7 +133,6 @@ async function migrateLegacyFile(connection) {
     const raw = await fs.readFile(LEGACY_FILE, 'utf8');
     const legacyUsers = JSON.parse(raw);
     if (!Array.isArray(legacyUsers) || legacyUsers.length === 0) {
-      await fs.rename(LEGACY_FILE, `${LEGACY_FILE}.bak`);
       return;
     }
 
@@ -221,7 +148,7 @@ async function migrateLegacyFile(connection) {
         const phoneNumber = normalizePhone(legacy.phoneNumber || '+550000000000');
         const { hash, salt } = await hashPassword(legacy.password || 'Alterar123');
         const apiToken = generateApiToken();
-        const credits = Number.isFinite(legacy.credits) ? legacy.credits : 0;
+        const credits = Number.isFinite(legacy.credits) ? Math.max(0, Math.round(legacy.credits)) : 0;
 
         await connection.run(
           `INSERT OR IGNORE INTO app_user (
@@ -254,20 +181,30 @@ async function migrateLegacyFile(connection) {
       }
     }
 
-    await fs.rename(LEGACY_FILE, `${LEGACY_FILE}.bak`);
-    console.log('[UserStore] Migração concluída. Arquivo legacy renomeado para users.json.bak');
+    console.log('[UserStore] Migração concluída. Mantendo arquivo users.json para referência.');
   } catch (error) {
     console.error('[UserStore] Não foi possível migrar users.json:', error);
   }
 }
 
+let ensurePromise = null;
+
 async function ensureDataFile() {
   await fs.mkdir(DATA_DIR, { recursive: true });
-  const connection = await db.getConnection();
-  await migrateLegacyFile(connection);
+  if (!ensurePromise) {
+    ensurePromise = (async () => {
+      const connection = await db.getConnection();
+      await migrateLegacyFile(connection);
+    })().catch((error) => {
+      ensurePromise = null;
+      throw error;
+    });
+  }
+  return ensurePromise;
 }
 
 async function listUsers() {
+  await ensureDataFile();
   const connection = await db.getConnection();
   const rows = await connection.all(`SELECT * FROM app_user ORDER BY datetime(createdAt) DESC`);
   return rows.map(sanitizeUser);
@@ -275,6 +212,7 @@ async function listUsers() {
 
 async function getUser(id) {
   if (!id) return null;
+  await ensureDataFile();
   const connection = await db.getConnection();
   const row = await connection.get(`SELECT * FROM app_user WHERE id = ?`, [id]);
   return sanitizeUser(row);
@@ -282,6 +220,7 @@ async function getUser(id) {
 
 async function getUserByEmail(email) {
   const value = normalizeEmail(email);
+  await ensureDataFile();
   const connection = await db.getConnection();
   const row = await connection.get(`SELECT * FROM app_user WHERE lower(email) = ?`, [value]);
   return row ? sanitizeUser(row) : null;
@@ -289,6 +228,7 @@ async function getUserByEmail(email) {
 
 async function getRawUserByEmail(email) {
   const value = normalizeEmail(email);
+  await ensureDataFile();
   const connection = await db.getConnection();
   return connection.get(`SELECT * FROM app_user WHERE lower(email) = ?`, [value]);
 }
@@ -296,6 +236,7 @@ async function getRawUserByEmail(email) {
 async function getRawUserByUsername(username) {
   const value = normalizeString(username).toLowerCase();
   if (!value) return null;
+  await ensureDataFile();
   const connection = await db.getConnection();
   return connection.get(`SELECT * FROM app_user WHERE lower(username) = ?`, [value]);
 }
@@ -304,20 +245,21 @@ async function assertUniqueFields({ email, username, discordId, rep4repId }, { i
   const connection = await db.getConnection();
   const clauses = [];
   const params = [];
+
   if (email) {
-    clauses.push(`lower(email) = ?`);
+    clauses.push('lower(email) = ?');
     params.push(email.toLowerCase());
   }
   if (username) {
-    clauses.push(`lower(username) = ?`);
+    clauses.push('lower(username) = ?');
     params.push(username.toLowerCase());
   }
   if (discordId) {
-    clauses.push(`discordId = ?`);
+    clauses.push('discordId = ?');
     params.push(discordId);
   }
   if (rep4repId) {
-    clauses.push(`lower(rep4repId) = ?`);
+    clauses.push('lower(rep4repId) = ?');
     params.push(rep4repId.toLowerCase());
   }
 
@@ -345,7 +287,9 @@ async function assertUniqueFields({ email, username, discordId, rep4repId }, { i
   }
 }
 
-async function createUserRecord(data, { defaultStatus = 'pending' } = {}) {
+async function createUserRecord(data, { defaultStatus = 'pending', allowRoleOverride = true } = {}) {
+  await ensureDataFile();
+
   const username = requireString(data.username, 'Informe um username.');
   const fullName = requireString(data.fullName || data.displayName, 'Informe o nome completo.');
   const email = normalizeEmail(data.email);
@@ -356,7 +300,11 @@ async function createUserRecord(data, { defaultStatus = 'pending' } = {}) {
   const phoneNumber = normalizePhone(data.phoneNumber || data.whatsapp || data.phone);
   const rep4repKey = normalizeString(data.rep4repKey || '');
   const credits = Number.isFinite(Number(data.credits)) ? Math.max(0, Math.round(Number(data.credits))) : 0;
-  const role = normalizeString(data.role) || 'customer';
+  const requestedRole = normalizeString(data.role);
+  const roleCandidates = new Set(['customer', 'admin']);
+  const role = allowRoleOverride && requestedRole && roleCandidates.has(requestedRole)
+    ? requestedRole
+    : 'customer';
   const status = normalizeString(data.status) || defaultStatus || 'pending';
 
   await assertUniqueFields(
@@ -369,19 +317,6 @@ async function createUserRecord(data, { defaultStatus = 'pending' } = {}) {
   const now = new Date().toISOString();
   const id = randomUUID();
   const apiToken = generateApiToken();
-  const user = {
-    id: randomUUID(),
-    displayName: name,
-    email: mail,
-    rep4repKey: normalizeString(rep4repKey),
-    credits: normalizeCredits(credits),
-    status: 'active',
-    role: 'customer',
-    notes: normalizeString(notes),
-    apiToken: generateApiToken(),
-    createdAt: now,
-    updatedAt: now,
-  };
 
   await connection.run(
     `INSERT INTO app_user (
@@ -415,14 +350,21 @@ async function createUserRecord(data, { defaultStatus = 'pending' } = {}) {
 }
 
 async function createUser(data = {}) {
-  return createUserRecord({ ...data, status: data.status || 'active' }, { defaultStatus: 'active' });
+  return createUserRecord(
+    { ...data, status: data.status || 'active' },
+    { defaultStatus: 'active', allowRoleOverride: true },
+  );
 }
 
 async function registerUser(data = {}) {
-  return createUserRecord({ ...data, credits: 0, status: 'pending' }, { defaultStatus: 'pending' });
+  return createUserRecord(
+    { ...data, credits: 0, status: 'pending', role: 'customer' },
+    { defaultStatus: 'pending', allowRoleOverride: false },
+  );
 }
 
 async function updateUser(id, updates = {}) {
+  await ensureDataFile();
   const connection = await db.getConnection();
   const current = await connection.get(`SELECT * FROM app_user WHERE id = ?`, [id]);
   if (!current) {
@@ -463,7 +405,11 @@ async function updateUser(id, updates = {}) {
     next.status = value;
   }
   if (updates.role !== undefined) {
-    next.role = normalizeString(updates.role) || current.role;
+    const value = normalizeString(updates.role);
+    if (value && !['customer', 'admin'].includes(value)) {
+      throw new Error('Nível de acesso inválido.');
+    }
+    next.role = value || current.role;
   }
   if (updates.credits !== undefined) {
     const creditsValue = Number(updates.credits);
@@ -476,7 +422,6 @@ async function updateUser(id, updates = {}) {
     const { hash, salt } = await hashPassword(updates.password);
     next.passwordHash = hash;
     next.passwordSalt = salt;
-
   }
 
   await assertUniqueFields(
@@ -536,6 +481,7 @@ async function adjustCredits(id, delta) {
     throw new Error('Informe um valor numérico para ajustar créditos.');
   }
 
+  await ensureDataFile();
   const connection = await db.getConnection();
   const current = await connection.get(`SELECT * FROM app_user WHERE id = ?`, [id]);
   if (!current) {
@@ -558,6 +504,7 @@ async function consumeCredits(id, amount = 1) {
     return getUser(id);
   }
 
+  await ensureDataFile();
   const connection = await db.getConnection();
   const current = await connection.get(`SELECT * FROM app_user WHERE id = ?`, [id]);
   if (!current) {
@@ -582,6 +529,7 @@ async function authenticateUser({ userId, token }) {
     return null;
   }
 
+  await ensureDataFile();
   const connection = await db.getConnection();
   const user = await connection.get(`SELECT * FROM app_user WHERE id = ?`, [userId]);
   if (!user) {
@@ -600,6 +548,7 @@ async function authenticateUser({ userId, token }) {
 }
 
 async function rotateApiToken(id) {
+  await ensureDataFile();
   const connection = await db.getConnection();
   const current = await connection.get(`SELECT * FROM app_user WHERE id = ?`, [id]);
   if (!current) {
@@ -618,6 +567,7 @@ async function loginUser({ identifier, password }) {
     throw new Error('Informe email ou username para entrar.');
   }
 
+  await ensureDataFile();
   const connection = await db.getConnection();
   const row = await connection.get(
     `SELECT * FROM app_user WHERE lower(email) = ? OR lower(username) = ?`,
@@ -639,6 +589,7 @@ async function loginUser({ identifier, password }) {
 }
 
 async function updateRep4repKey(id, rep4repKey) {
+  await ensureDataFile();
   const connection = await db.getConnection();
   const current = await connection.get(`SELECT * FROM app_user WHERE id = ?`, [id]);
   if (!current) {
@@ -649,83 +600,15 @@ async function updateRep4repKey(id, rep4repKey) {
   const updatedAt = new Date().toISOString();
   await connection.run(`UPDATE app_user SET rep4repKey = ?, updatedAt = ? WHERE id = ?`, [key, updatedAt, id]);
   return sanitizeUser({ ...current, rep4repKey: key, updatedAt });
-  const nextCredits = current.credits + Math.round(amount);
-  if (nextCredits < 0) {
-    throw new Error('Créditos insuficientes para remover.');
-  }
-
-  const credits = normalizeCredits(nextCredits);
-  const updated = { ...current, credits, updatedAt: new Date().toISOString() };
-  users[index] = updated;
-  await writeUsers(users);
-  return updated;
 }
 
-async function consumeCredits(id, amount = 1) {
-  const qty = Math.max(0, Math.floor(Number(amount)));
-  if (qty <= 0) {
-    return getUser(id);
-  }
-
-  const users = await readUsers();
-  const index = users.findIndex((user) => user.id === id);
-  if (index === -1) {
-    throw new Error('Usuário não encontrado.');
-  }
-
-  const current = users[index];
-  if (current.credits < qty) {
-    throw new Error('Créditos insuficientes.');
-  }
-
-  const updated = {
-    ...current,
-    credits: current.credits - qty,
-    updatedAt: new Date().toISOString(),
-  };
-  users[index] = updated;
-  await writeUsers(users);
-  return updated;
-}
-
-async function rotateApiToken(id) {
-  const users = await readUsers();
-  const index = users.findIndex((user) => user.id === id);
-  if (index === -1) {
-    throw new Error('Usuário não encontrado.');
-  }
-
-  const updated = {
-    ...users[index],
-    apiToken: generateApiToken(),
-    updatedAt: new Date().toISOString(),
-  };
-
-  users[index] = updated;
-  await writeUsers(users);
-  return updated;
-}
-
-async function authenticateUser({ userId, token }) {
-  if (!userId || !token) {
-    return null;
-  }
-
-  const users = await readUsers();
-  const user = users.find((item) => item.id === userId);
-  if (!user) {
-    return null;
-  }
-
-  if (user.status !== 'active') {
-    return null;
-  }
-
-  if (user.apiToken !== token) {
-    return null;
-  }
-
-  return user;
+async function findActiveAdmin() {
+  await ensureDataFile();
+  const connection = await db.getConnection();
+  const row = await connection.get(
+    `SELECT * FROM app_user WHERE role = 'admin' AND status = 'active' ORDER BY datetime(updatedAt) DESC LIMIT 1`,
+  );
+  return sanitizeUser(row);
 }
 
 module.exports = {
@@ -742,5 +625,6 @@ module.exports = {
   rotateApiToken,
   loginUser,
   updateRep4repKey,
-
+  findActiveAdmin,
 };
+

--- a/web/views/dashboard.ejs
+++ b/web/views/dashboard.ejs
@@ -8,6 +8,11 @@
             <button class="btn btn--secondary" data-command="backup">💾 Criar backup</button>
             <a class="btn btn--ghost" href="<%= base %>/logs">📜 Ver logs</a>
         </div>
+        <div class="watchdog-banner" data-watchdog-state-container>
+            <span class="badge badge--muted">Modo vigia</span>
+            <span class="watchdog-banner__state" data-watchdog-state data-state="off">desligado</span>
+            <span class="watchdog-banner__info">última execução: <strong data-watchdog-last-run>—</strong></span>
+        </div>
             <p class="hero__hint">Dica: configure o arquivo <code>accounts.txt</code>, mantenha o bot do terminal rodando com a sua key e libere créditos apenas após validar os dados do cliente.</p>
         <p class="hero__hint">Dica: configure o arquivo <code>accounts.txt</code> e garanta que o <code>REP4REP_KEY</code> está definido antes de rodar as automações.</p>
     </div>
@@ -61,6 +66,37 @@
         </header>
         <div class="card__body">
             <pre class="command-output" data-command-output>Selecione um comando para ver o resultado aqui.</pre>
+        </div>
+    </article>
+    <article class="card">
+        <header class="card__header">
+            <div>
+                <h2>Modo VPS / Vigia automático</h2>
+                <p>Mantenha o bot ativo em segundo plano verificando prioridades a cada ciclo.</p>
+            </div>
+        </header>
+        <div class="card__body card__body--spaced watchdog-card">
+            <dl class="watchdog-stats">
+                <div>
+                    <dt>Status</dt>
+                    <dd data-watchdog-state data-state="off">desligado</dd>
+                </div>
+                <div>
+                    <dt>Intervalo</dt>
+                    <dd data-watchdog-interval>--</dd>
+                </div>
+                <div>
+                    <dt>Última execução</dt>
+                    <dd data-watchdog-last-run>—</dd>
+                </div>
+            </dl>
+            <p class="watchdog-error" data-watchdog-error></p>
+            <div class="watchdog-actions">
+                <button class="btn btn--primary" data-command="watchdogStart">Iniciar vigia</button>
+                <button class="btn btn--outline" data-command="watchdogStop">Parar</button>
+                <button class="btn btn--ghost" data-watchdog-refresh>Atualizar status</button>
+            </div>
+            <p class="watchdog-note">O vigia executa o <strong>autoRun prioritário</strong> em ciclos e respeita os limites (100 contas / 1000 comentários). Configure o intervalo via <code>KEEPALIVE_INTERVAL_MINUTES</code> no seu <code>.env</code>.</p>
         </div>
     </article>
 </section>
@@ -185,5 +221,77 @@
 </section>
 
 <div class="toast" data-toast hidden></div>
+
+<div class="user-editor" data-user-editor>
+    <div class="user-editor__container">
+        <header class="user-editor__header">
+            <h3 data-user-editor-title>Gerenciar cliente</h3>
+            <button type="button" class="btn btn--pill" data-user-editor-close>✕</button>
+        </header>
+        <form class="user-editor__form" data-user-editor-form>
+            <div class="user-editor__grid">
+                <label>
+                    <span>Nome completo</span>
+                    <input type="text" name="fullName" required />
+                </label>
+                <label>
+                    <span>Username</span>
+                    <input type="text" name="username" required />
+                </label>
+                <label>
+                    <span>Email</span>
+                    <input type="email" name="email" required />
+                </label>
+                <label>
+                    <span>Telefone / WhatsApp</span>
+                    <input type="tel" name="phoneNumber" required />
+                </label>
+                <label>
+                    <span>Discord ID</span>
+                    <input type="text" name="discordId" required />
+                </label>
+                <label>
+                    <span>Rep4Rep ID</span>
+                    <input type="text" name="rep4repId" required />
+                </label>
+                <label class="user-editor__field--wide">
+                    <span>Chave Rep4Rep</span>
+                    <input type="text" name="rep4repKey" placeholder="Cole aqui a chave do cliente" />
+                </label>
+                <label>
+                    <span>Data de nascimento</span>
+                    <input type="date" name="dateOfBirth" required />
+                </label>
+                <label>
+                    <span>Créditos</span>
+                    <input type="number" name="credits" min="0" step="1" />
+                </label>
+                <label>
+                    <span>Status</span>
+                    <select name="status" required>
+                        <option value="active">ativo</option>
+                        <option value="pending">pendente</option>
+                        <option value="blocked">bloqueado</option>
+                    </select>
+                </label>
+                <label>
+                    <span>Nível de acesso</span>
+                    <select name="role" required>
+                        <option value="customer">cliente</option>
+                        <option value="admin">admin</option>
+                    </select>
+                </label>
+                <label>
+                    <span>Nova senha (opcional)</span>
+                    <input type="password" name="password" placeholder="Deixe vazio para manter" />
+                </label>
+            </div>
+            <footer class="user-editor__footer">
+                <button type="submit" class="btn btn--primary">Guardar alterações</button>
+                <button type="button" class="btn btn--ghost" data-user-editor-close>Cancelar</button>
+            </footer>
+        </form>
+    </div>
+</div>
 
 <%- include('partials/layout-end', { includePanelScript: true }) %>

--- a/web/views/partials/layout-end.ejs
+++ b/web/views/partials/layout-end.ejs
@@ -3,6 +3,59 @@
             <span>&copy; <%= new Date().getFullYear() %> Rep4Rep Bot · Painel administrativo</span>
         </footer>
     </div>
+    <script>
+        (function () {
+            const toggle = document.querySelector('[data-translate-toggle]');
+            const dropdown = document.querySelector('[data-translate-container]');
+            if (!toggle || !dropdown) {
+                return;
+            }
+
+            const closeDropdown = () => {
+                dropdown.hidden = true;
+                toggle.setAttribute('aria-expanded', 'false');
+            };
+
+            toggle.addEventListener('click', (event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                const willOpen = dropdown.hidden;
+                dropdown.hidden = !willOpen;
+                toggle.setAttribute('aria-expanded', String(willOpen));
+            });
+
+            document.addEventListener('click', (event) => {
+                if (!dropdown.contains(event.target) && !toggle.contains(event.target)) {
+                    closeDropdown();
+                }
+            });
+
+            document.addEventListener('keydown', (event) => {
+                if (event.key === 'Escape') {
+                    closeDropdown();
+                }
+            });
+
+            window.googleTranslateElementInit = function () {
+                if (!window.google || !window.google.translate) {
+                    return;
+                }
+                new window.google.translate.TranslateElement(
+                    {
+                        pageLanguage: 'pt',
+                        includedLanguages: 'pt,en,es,fr,it,de',
+                        layout: window.google.translate.TranslateElement.InlineLayout.SIMPLE,
+                    },
+                    'google_translate_element',
+                );
+            };
+
+            const script = document.createElement('script');
+            script.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
+            script.defer = true;
+            document.body.appendChild(script);
+        })();
+    </script>
     <% if (includePanelScript) { %>
         <script>window.__PANEL_BASE__ = '<%= typeof base !== 'undefined' ? base : '' %>';</script>
         <script src="/panel.js" defer></script>

--- a/web/views/partials/layout-start.ejs
+++ b/web/views/partials/layout-start.ejs
@@ -20,9 +20,20 @@
                     <p class="brand__subtitle">Automação segura para o ecossistema Rep4Rep</p>
                 </div>
             </div>
-            <nav class="app-nav">
-                <a href="<%= base %>/" class="app-nav__link <%= page === 'dashboard' ? 'is-active' : '' %>">Dashboard</a>
-                <a href="<%= base %>/logs" class="app-nav__link <%= page === 'logs' ? 'is-active' : '' %>">Logs</a>
-            </nav>
+            <div class="app-header__right">
+                <nav class="app-nav">
+                    <a href="<%= base %>/" class="app-nav__link <%= page === 'dashboard' ? 'is-active' : '' %>">Dashboard</a>
+                    <a href="<%= base %>/logs" class="app-nav__link <%= page === 'logs' ? 'is-active' : '' %>">Logs</a>
+                </nav>
+                <div class="language-switch" data-language-switch>
+                    <button type="button" class="btn btn--ghost" data-translate-toggle aria-haspopup="true" aria-expanded="false">
+                        🌐 <span>Idioma</span>
+                    </button>
+                    <div class="language-switch__dropdown" data-translate-container hidden>
+                        <div id="google_translate_element" class="language-switch__widget"></div>
+                        <p class="language-switch__hint">Tradução automática via Google Translate.</p>
+                    </div>
+                </div>
+            </div>
         </header>
         <main class="app-main">


### PR DESCRIPTION
## Summary
- add automatic maintenance scheduling with 3-day backups and a keep-alive loop reusable by the CLI and panel
- expose watchdog controls and a full client editor in the admin UI while updating styles and README guidance
- provide Windows helper scripts plus start.js flags so the stack can run headless or open the browser on demand

## Testing
- node -e "require('./src/util.cjs')"
- node -e "require('./web/routes/user.js')"
- node -e "(async () => { const store = require('./web/services/userStore.js'); const users = await store.listUsers(); console.log('users', users.length); process.exit(0); })().catch(err => { console.error(err); process.exit(1); });"

------
https://chatgpt.com/codex/tasks/task_e_68caa95a8f088325baccdd0faaabbaf7