### PR TITLE
fix: clean duplicated webhook and queue logic

### DIFF
--- a/src/util.cjs
+++ b/src/util.cjs
@@ -130,8 +130,6 @@ async function sendDiscordWebhook(payload = {}, options = {}) {
   const overrideUrl = (options.overrideUrl || options.webhookUrl || '').trim();
   const targetUrl = overrideUrl || DISCORD_WEBHOOK_URL;
   if (!targetUrl) {
-async function sendDiscordWebhook(payload = {}) {
-  if (!DISCORD_WEBHOOK_URL) {
     return false;
   }
 
@@ -149,13 +147,6 @@ async function sendDiscordWebhook(payload = {}) {
     };
 
     const response = await fetch(targetUrl, {
-    const body = {
-      username: DISCORD_WEBHOOK_USERNAME,
-      ...(DISCORD_WEBHOOK_AVATAR_URL ? { avatar_url: DISCORD_WEBHOOK_AVATAR_URL } : {}),
-      ...payload,
-    };
-
-    const response = await fetch(DISCORD_WEBHOOK_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
@@ -173,7 +164,6 @@ async function sendDiscordWebhook(payload = {}) {
       const snippet = details ? details.slice(0, 140) : '';
       log(
         `⚠️ Webhook do Discord${targetLabel} respondeu com status ${response.status}${
-        `⚠️ Webhook do Discord respondeu com status ${response.status}${
           snippet ? ` – ${snippet}` : ''
         }`,
       );
@@ -184,8 +174,6 @@ async function sendDiscordWebhook(payload = {}) {
   } catch (error) {
     const targetLabel = overrideUrl ? ' (customizado)' : '';
     log(`⚠️ Falha ao enviar webhook do Discord${targetLabel}: ${error.message}`);
-
-    log(`⚠️ Falha ao enviar webhook do Discord: ${error.message}`);
     return false;
   }
 }
@@ -238,13 +226,6 @@ async function announceQueueEvent(event = {}) {
   const client = event.client || job?.user || null;
   const clientLabel = formatClientLabel(client);
   const clientWebhookUrl = (client?.discordWebhookUrl || '').trim();
-  if (!DISCORD_WEBHOOK_URL) {
-    return false;
-  }
-
-  const job = event.job || null;
-  const client = event.client || job?.user || null;
-  const clientLabel = formatClientLabel(client);
   const embed = {
     timestamp: new Date().toISOString(),
     fields: [],
@@ -343,7 +324,6 @@ async function announceQueueEvent(event = {}) {
 
   const results = await Promise.allSettled(deliveries);
   return results.some((result) => result.status === 'fulfilled' && result.value === true);
-  return sendDiscordWebhook({ embeds: [embed] });
 }
 
 function readMaintenanceMetadata() {
@@ -1210,8 +1190,6 @@ async function prioritizedAutoRun(options = {}) {
       } catch (notifyError) {
         log(`⚠️ Falha ao notificar lote prioritário: ${notifyError.message}`);
       }
-      await announceQueueEvent({ type: 'owner.completed', summary, webhookUrl: ownerWebhookUrl, client: ownerUser });
-      await announceQueueEvent({ type: 'owner.completed', summary });
       if (summary.totalComments > 0) {
         log('Pedidos do proprietário atendidos. Continuando com a fila de clientes.');
       }
@@ -1223,37 +1201,16 @@ async function prioritizedAutoRun(options = {}) {
   }
 
   let completedJobs = 0;
-  let processedJobs = 0;
-
-  while (true) {
-    let job;
-    try {
-      job = await runQueue.takeNextPendingJob();
-    } catch (error) {
-      log(`❌ Falha ao obter próxima ordem da fila: ${error.message}`);
-      break;
-    }
-
-    if (!job) {
-      break;
-    }
 
   const processJob = async (job) => {
     const client = job.user || (await userStore.getUser(job.userId));
     if (!client) {
-      return failQueuedJob(job, null, 'Usuário não encontrado.', `❌ Pedido ${job.id} removido da fila: usuário inexistente.`);
-      const failedJob = await runQueue.failJob(job.id, 'Usuário não encontrado.');
-      log(`❌ Pedido ${job.id} removido da fila: usuário inexistente.`);
-      try {
-        await announceQueueEvent({
-          type: 'job.failed',
-          job: failedJob,
-          error: 'Usuário não encontrado.',
-        });
-      } catch (notifyError) {
-        log(`⚠️ Falha ao notificar erro via webhook: ${notifyError.message}`);
-      }
-      continue;
+      return failQueuedJob(
+        job,
+        null,
+        'Usuário não encontrado.',
+        `❌ Pedido ${job.id} removido da fila: usuário inexistente.`,
+      );
     }
 
     const clientLabel = formatClientLabel(client);
@@ -1283,51 +1240,6 @@ async function prioritizedAutoRun(options = {}) {
         'Chave Rep4Rep não configurada.',
         `⚠️ ${clientLabel} ignorado: key Rep4Rep ausente.`,
       );
-      const failedJob = await runQueue.failJob(job.id, 'Pedido bloqueado pelo filtro do operador.');
-      log(`⚠️ Pedido ${job.id} ignorado (filtro do operador).`);
-      try {
-        await announceQueueEvent({
-          type: 'job.failed',
-          job: failedJob,
-          client,
-          error: 'Pedido bloqueado pelo filtro do operador.',
-        });
-      } catch (notifyError) {
-        log(`⚠️ Falha ao notificar erro via webhook: ${notifyError.message}`);
-      }
-      continue;
-    }
-
-    if (client.status !== 'active') {
-      const failedJob = await runQueue.failJob(job.id, 'Conta inativa ou bloqueada.');
-      log(`⚠️ ${clientLabel} ignorado: conta não está ativa.`);
-      try {
-        await announceQueueEvent({
-          type: 'job.failed',
-          job: failedJob,
-          client,
-          error: 'Conta inativa ou bloqueada.',
-        });
-      } catch (notifyError) {
-        log(`⚠️ Falha ao notificar erro via webhook: ${notifyError.message}`);
-      }
-      continue;
-    }
-
-    if (!client.rep4repKey) {
-      const failedJob = await runQueue.failJob(job.id, 'Chave Rep4Rep não configurada.');
-      log(`⚠️ ${clientLabel} ignorado: key Rep4Rep ausente.`);
-      try {
-        await announceQueueEvent({
-          type: 'job.failed',
-          job: failedJob,
-          client,
-          error: 'Chave Rep4Rep não configurada.',
-        });
-      } catch (notifyError) {
-        log(`⚠️ Falha ao notificar erro via webhook: ${notifyError.message}`);
-      }
-      continue;
     }
 
     const isAdmin = client.role === 'admin';
@@ -1339,46 +1251,10 @@ async function prioritizedAutoRun(options = {}) {
         'Créditos insuficientes.',
         `⚠️ ${clientLabel} sem créditos suficientes. Pedido removido.`,
       );
-      const failedJob = await runQueue.failJob(job.id, 'Créditos insuficientes.');
-      log(`⚠️ ${clientLabel} sem créditos suficientes. Pedido removido.`);
-      try {
-        await announceQueueEvent({
-          type: 'job.failed',
-          job: failedJob,
-          client,
-          error: 'Créditos insuficientes.',
-        });
-      } catch (notifyError) {
-        log(`⚠️ Falha ao notificar erro via webhook: ${notifyError.message}`);
-      }
-      continue;
     }
 
     const jobMaxComments = Math.min(1000, Math.max(1, job.maxCommentsPerAccount || maxComments));
     const jobAccountLimit = Math.min(100, Math.max(1, job.accountLimit || accountLimit));
-
-    let usedCredits = 0;
-    const upstreamTaskHandler = baseRunOptions.onTaskComplete;
-    const onTaskComplete = async (payload) => {
-      if (typeof upstreamTaskHandler === 'function') {
-        try {
-          const upstreamResult = await upstreamTaskHandler(payload);
-          if (upstreamResult === false) {
-            return false;
-          }
-        } catch (callbackError) {
-          log(`⚠️ onTaskComplete custom handler falhou: ${callbackError.message}`);
-        }
-      }
-
-      if (isAdmin) {
-        return true;
-      }
-
-      usedCredits += 1;
-      return usedCredits < creditLimit;
-    };
-
 
     let usedCredits = 0;
     const upstreamTaskHandler = baseRunOptions.onTaskComplete;
@@ -1427,12 +1303,13 @@ async function prioritizedAutoRun(options = {}) {
           }
         } catch (creditError) {
           log(`⚠️ Falha ao debitar créditos de ${clientLabel}: ${creditError.message}`);
-          log(`⚠️ Falha ao debitar créditos de ${client.username || client.id}: ${creditError.message}`);
         }
       }
 
       if (!isAdmin) {
-        const remaining = updatedUser?.credits ?? (Number.isFinite(creditLimit) ? Math.max(0, creditLimit - consumed) : 0);
+        const remaining =
+          updatedUser?.credits ??
+          (Number.isFinite(creditLimit) ? Math.max(0, creditLimit - consumed) : 0);
         log(`[${clientLabel}] Créditos debitados: ${consumed}. Restantes: ${remaining}.`);
       }
 
@@ -1479,7 +1356,6 @@ async function prioritizedAutoRun(options = {}) {
 
       if (totalComments > 0) {
         log(`✅ Execução concluída para ${clientLabel}.`);
-        log(`✅ Execução concluída para ${client.username || client.id}.`);
       } else {
         log(`ℹ️ Nenhum comentário pendente para ${clientLabel}.`);
       }
@@ -1512,14 +1388,6 @@ async function prioritizedAutoRun(options = {}) {
     result.clients.push(outcome);
     if (outcome.status === 'completed') {
       completedJobs += 1;
-      const failedJob = await runQueue.failJob(job.id, error.message);
-      log(`❌ Falha ao processar ${clientLabel}: ${error.message}`);
-      result.clients.push({ client, error: error.message, queueJob: failedJob, status: 'failed' });
-      try {
-        await announceQueueEvent({ type: 'job.failed', job: failedJob, client, error: error.message });
-      } catch (notifyError) {
-        log(`⚠️ Falha ao notificar erro via webhook: ${notifyError.message}`);
-      }
     }
   }
 

--- a/start.js
+++ b/start.js
@@ -1,7 +1,6 @@
 const { fork } = require('child_process');
 const path = require('path');
 const minimist = require('minimist');
-const open = require('open');
 
 const args = minimist(process.argv.slice(2), {
   boolean: ['no-browser', 'nobrowser', 'noBrowser'],

--- a/web/routes/user.js
+++ b/web/routes/user.js
@@ -197,12 +197,6 @@ router.post('/run', async (req, res) => {
 
   const sanitizedMax = sanitizeOptionalLimit(maxCommentsPerAccount, DEFAULT_MAX_COMMENTS, 1000);
   const sanitizedAccounts = sanitizeOptionalLimit(accountLimit, DEFAULT_ACCOUNT_LIMIT, 100);
-  const sanitizedMax = Number.isFinite(Number(maxCommentsPerAccount))
-    ? Math.max(1, Math.min(1000, Math.floor(Number(maxCommentsPerAccount))))
-    : DEFAULT_MAX_COMMENTS;
-  const sanitizedAccounts = Number.isFinite(Number(accountLimit))
-    ? Math.max(1, Math.min(100, Math.floor(Number(accountLimit))))
-    : DEFAULT_ACCOUNT_LIMIT;
 
   try {
     const enqueue = await runQueue.enqueueJob({


### PR DESCRIPTION
## Summary
- deduplicate the Discord webhook helper so the dynamic import path can run without syntax errors
- rebuild the queue event broadcaster and prioritized auto-run flow to remove conflicting duplicate code and restore client processing
- simplify the user run endpoint limit sanitization to rely on the shared helper without redundant logic

## Testing
- npm start *(manually terminated after verifying successful startup)*

------
https://chatgpt.com/codex/tasks/task_e_68cadca364408325b64f06650ac41051