### PR TITLE
Fix base URL handling for dashboard links

### DIFF
--- a/web/views/dashboard.ejs
+++ b/web/views/dashboard.ejs
@@ -1,4 +1,5 @@
-<%- include('partials/layout-start', { title: title || 'Painel', page }) %>
+<% const basePath = typeof baseUrl !== 'undefined' ? baseUrl : ''; %>
+<%- include('partials/layout-start', { title: title || 'Painel', page, basePath }) %>
 <section class="hero">
     <div class="hero__content">
         <h1>Centro de Controle Rep4Rep</h1>
@@ -6,7 +7,7 @@
         <div class="hero__actions">
             <button class="btn btn--primary" data-command="autoRun">▶️ Executar autoRun</button>
             <button class="btn btn--secondary" data-command="backup">💾 Criar backup</button>
-            <a class="btn btn--ghost" href="<%= base %>/logs">📜 Ver logs</a>
+            <a class="btn btn--ghost" href="<%= basePath %>/logs">📜 Ver logs</a>
         </div>
         <div class="watchdog-banner" data-watchdog-state-container>
             <span class="badge badge--muted">Modo vigia</span>

--- a/web/views/partials/layout-start.ejs
+++ b/web/views/partials/layout-start.ejs
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
-    <% const base = typeof baseUrl !== 'undefined' ? baseUrl : ''; %>
+    <% const baseHref = typeof basePath !== 'undefined' ? basePath : (typeof baseUrl !== 'undefined' ? baseUrl : ''); %>
     <div class="app-shell">
         <header class="app-header">
             <div class="brand">
@@ -22,8 +22,8 @@
             </div>
             <div class="app-header__right">
                 <nav class="app-nav">
-                    <a href="<%= base %>/" class="app-nav__link <%= page === 'dashboard' ? 'is-active' : '' %>">Dashboard</a>
-                    <a href="<%= base %>/logs" class="app-nav__link <%= page === 'logs' ? 'is-active' : '' %>">Logs</a>
+                    <a href="<%= baseHref %>/" class="app-nav__link <%= page === 'dashboard' ? 'is-active' : '' %>">Dashboard</a>
+                    <a href="<%= baseHref %>/logs" class="app-nav__link <%= page === 'logs' ? 'is-active' : '' %>">Logs</a>
                 </nav>
                 <div class="language-switch" data-language-switch>
                     <button type="button" class="btn btn--ghost" data-translate-toggle aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
## Summary
- derive a reusable base path before rendering the dashboard template
- ensure the shared layout resolves navigation links from a passed base path or Express baseUrl

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cae938f7ac83259e740d0bfbe52f89