### PR TITLE
Fix admin panel base path handling

### DIFF
--- a/web/public/panel.js
+++ b/web/public/panel.js
@@ -1,5 +1,8 @@
 (function () {
-  const panelBase = window.__PANEL_BASE__ || '';
+  const fallbackBase = typeof window !== 'undefined' && window.location?.pathname?.startsWith('/admin')
+    ? '/admin'
+    : '';
+  const panelBase = window.__PANEL_BASE__ || fallbackBase || '';
   const buildUrl = (path) => `${panelBase}${path}`;
 
   const outputEl = document.querySelector('[data-command-output]');

--- a/web/views/dashboard.ejs
+++ b/web/views/dashboard.ejs
@@ -1,4 +1,5 @@
-<%- include('partials/layout-start', { title: title || 'Painel', page }) %>
+<% const panelBase = typeof baseUrl === 'string' && baseUrl ? baseUrl : ''; %>
+<%- include('partials/layout-start', { title: title || 'Painel', page, panelBase }) %>
 <section class="hero">
     <div class="hero__content">
         <h1>Centro de Controle Rep4Rep</h1>
@@ -6,7 +7,7 @@
         <div class="hero__actions">
             <button class="btn btn--primary" data-command="autoRun">▶️ Executar autoRun</button>
             <button class="btn btn--secondary" data-command="backup">💾 Criar backup</button>
-            <a class="btn btn--ghost" href="<%= base %>/logs">📜 Ver logs</a>
+            <a class="btn btn--ghost" href="<%= panelBase %>/logs">📜 Ver logs</a>
         </div>
         <div class="watchdog-banner" data-watchdog-state-container>
             <span class="badge badge--muted">Modo vigia</span>
@@ -381,5 +382,4 @@
     </div>
 </div>
 
-<%- include('partials/layout-end', { includePanelScript: true, initialQueue: initialQueue }) %>
-<%- include('partials/layout-end', { includePanelScript: true }) %>
+<%- include('partials/layout-end', { includePanelScript: true, initialQueue: initialQueue, panelBase }) %>

--- a/web/views/logs.ejs
+++ b/web/views/logs.ejs
@@ -1,4 +1,5 @@
-<%- include('partials/layout-start', { title: title || 'Logs', page }) %>
+<% const panelBase = typeof baseUrl === 'string' && baseUrl ? baseUrl : ''; %>
+<%- include('partials/layout-start', { title: title || 'Logs', page, panelBase }) %>
 <section class="card card--full">
     <header class="card__header">
         <div>
@@ -24,19 +25,4 @@
         <% } %>
     </div>
 </section>
-<%- include('partials/layout-end', { includePanelScript: false }) %>
-<!DOCTYPE html>
-<html>
-<head><title>Logs</title></head>
-<body>
-<h2>📜 Logs</h2>
-<% if (!logs.length) { %>
-    <p>Nenhum log encontrado.</p>
-<% } else { %>
-    <% logs.forEach(log => { %>
-        <h3><%= log.name %></h3>
-        <pre><%= log.content %></pre>
-    <% }) %>
-<% } %>
-</body>
-</html>
+<%- include('partials/layout-end', { includePanelScript: false, panelBase }) %>

--- a/web/views/partials/layout-end.ejs
+++ b/web/views/partials/layout-end.ejs
@@ -56,9 +56,18 @@
             document.body.appendChild(script);
         })();
     </script>
+    <% const panelBaseHref =
+        typeof panelBase === 'string' && panelBase
+            ? panelBase
+            : typeof basePath === 'string' && basePath
+            ? basePath
+            : typeof baseUrl === 'string'
+            ? baseUrl
+            : '';
+    %>
     <% if (includePanelScript) { %>
         <script>
-            window.__PANEL_BASE__ = '<%= typeof base !== 'undefined' ? base : '' %>';
+            window.__PANEL_BASE__ = <%- JSON.stringify(panelBaseHref) %>;
             window.__INITIAL_QUEUE__ = <%- JSON.stringify(typeof initialQueue !== 'undefined' ? initialQueue : null) %>;
         </script>
         <script src="/panel.js" defer></script>

--- a/web/views/partials/layout-start.ejs
+++ b/web/views/partials/layout-start.ejs
@@ -10,7 +10,15 @@
     <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
-    <% const base = typeof baseUrl !== 'undefined' ? baseUrl : ''; %>
+    <% const baseHref =
+        typeof panelBase === 'string' && panelBase
+            ? panelBase
+            : typeof basePath === 'string' && basePath
+            ? basePath
+            : typeof baseUrl === 'string'
+            ? baseUrl
+            : '';
+    %>
     <div class="app-shell">
         <header class="app-header">
             <div class="brand">
@@ -22,8 +30,8 @@
             </div>
             <div class="app-header__right">
                 <nav class="app-nav">
-                    <a href="<%= base %>/" class="app-nav__link <%= page === 'dashboard' ? 'is-active' : '' %>">Dashboard</a>
-                    <a href="<%= base %>/logs" class="app-nav__link <%= page === 'logs' ? 'is-active' : '' %>">Logs</a>
+                    <a href="<%= baseHref %>/" class="app-nav__link <%= page === 'dashboard' ? 'is-active' : '' %>">Dashboard</a>
+                    <a href="<%= baseHref %>/logs" class="app-nav__link <%= page === 'logs' ? 'is-active' : '' %>">Logs</a>
                 </nav>
                 <div class="language-switch" data-language-switch>
                     <button type="button" class="btn btn--ghost" data-translate-toggle aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
## Summary
- resolve the admin panel base path in each view before including the shared layout
- propagate the resolved base path through the layout partials so navigation links and scripts stay scoped under /admin
- fall back to the current location on the front-end and remove the duplicate markup in the logs template

## Testing
- PANEL_USERNAME=admin PANEL_PASSWORD=secret node web/server.js
- curl -s -u admin:secret http://localhost:3000/admin | grep "__PANEL_BASE__"


------
https://chatgpt.com/codex/tasks/task_e_68cae938f7ac83259e740d0bfbe52f89