### PR TITLE
Improve admin panel UX and automate backups

### DIFF
--- a/web/public/language.js
+++ b/web/public/language.js
@@ -1,0 +1,211 @@
+(function () {
+  const languages = {
+    pt: { label: 'Português', documentLang: 'pt-BR' },
+    en: { label: 'English', documentLang: 'en' },
+  };
+  const defaultLanguage = 'pt';
+  let currentLanguage = defaultLanguage;
+
+  function isSupported(lang) {
+    return Object.prototype.hasOwnProperty.call(languages, lang);
+  }
+
+  function getPreferredLanguage() {
+    const stored = localStorage.getItem('preferredLanguage');
+    if (stored && isSupported(stored)) {
+      return stored;
+    }
+
+    const cookieMatch = document.cookie.match(/(?:^|;\s*)googtrans=([^;]+)/i);
+    if (cookieMatch) {
+      const parts = decodeURIComponent(cookieMatch[1]).split('/');
+      const candidate = parts[parts.length - 1];
+      if (candidate && isSupported(candidate)) {
+        return candidate;
+      }
+    }
+
+    return defaultLanguage;
+  }
+
+  function setCookie(name, value) {
+    const expires = new Date();
+    expires.setFullYear(expires.getFullYear() + 1);
+    const encodedValue = encodeURIComponent(value);
+    document.cookie = `${name}=${encodedValue};expires=${expires.toUTCString()};path=/`;
+
+    const host = window.location.hostname;
+    const isIp = /^\d+(?:\.\d+){3}$/.test(host);
+    if (host && host.includes('.') && !isIp) {
+      const domain = host.replace(/^www\./i, '');
+      document.cookie = `${name}=${encodedValue};expires=${expires.toUTCString()};path=/;domain=.${domain}`;
+    }
+  }
+
+  function updateUi(lang) {
+    const entry = languages[lang] || languages[defaultLanguage];
+    document.querySelectorAll('[data-language-label]').forEach((el) => {
+      el.textContent = entry.label;
+    });
+
+    document.documentElement.setAttribute('lang', entry.documentLang || lang);
+
+    document.querySelectorAll('[data-language-option]').forEach((button) => {
+      const isActive = button.dataset.languageOption === lang;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-checked', String(isActive));
+    });
+  }
+
+  function triggerTranslate(lang) {
+    const apply = () => {
+      const combo = document.querySelector('.goog-te-combo');
+      if (!combo) {
+        return false;
+      }
+      if (combo.value !== lang) {
+        combo.value = lang;
+      }
+      combo.dispatchEvent(new Event('change'));
+      return true;
+    };
+
+    if (apply()) {
+      return;
+    }
+
+    const observer = new MutationObserver(() => {
+      if (apply()) {
+        observer.disconnect();
+      }
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+    setTimeout(() => observer.disconnect(), 10_000);
+  }
+
+  function persistLanguage(lang) {
+    const normalized = isSupported(lang) ? lang : defaultLanguage;
+    const cookieValue = `/pt/${normalized}`;
+    setCookie('googtrans', cookieValue);
+    localStorage.setItem('preferredLanguage', normalized);
+  }
+
+  function setLanguage(lang, { persist = true } = {}) {
+    const normalized = isSupported(lang) ? lang : defaultLanguage;
+    currentLanguage = normalized;
+    if (persist) {
+      persistLanguage(normalized);
+    }
+    updateUi(normalized);
+    triggerTranslate(normalized);
+  }
+
+  function ensureHiddenContainer() {
+    const container = document.getElementById('google_translate_container');
+    if (container) {
+      container.style.position = 'absolute';
+      container.style.width = '1px';
+      container.style.height = '1px';
+      container.style.overflow = 'hidden';
+      container.style.clip = 'rect(0 0 0 0)';
+      container.style.clipPath = 'inset(50%)';
+      container.style.whiteSpace = 'nowrap';
+    }
+  }
+
+  function loadGoogleTranslate() {
+    if (window.googleTranslateElementInit) {
+      return;
+    }
+
+    ensureHiddenContainer();
+
+    window.googleTranslateElementInit = function () {
+      if (!window.google || !window.google.translate) {
+        return;
+      }
+
+      new window.google.translate.TranslateElement(
+        {
+          pageLanguage: 'pt',
+          includedLanguages: Object.keys(languages).join(','),
+          layout: window.google.translate.TranslateElement.InlineLayout.SIMPLE,
+          autoDisplay: false,
+        },
+        'google_translate_container',
+      );
+
+      triggerTranslate(currentLanguage);
+    };
+
+    const script = document.createElement('script');
+    script.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
+    script.async = true;
+    script.defer = true;
+    document.head.appendChild(script);
+  }
+
+  function closeDropdown(dropdown, toggle) {
+    dropdown.hidden = true;
+    if (toggle) {
+      toggle.setAttribute('aria-expanded', 'false');
+    }
+  }
+
+  function setupDropdown() {
+    const toggle = document.querySelector('[data-language-toggle]');
+    const dropdown = document.querySelector('[data-language-dropdown]');
+    if (!toggle || !dropdown) {
+      return;
+    }
+
+    toggle.addEventListener('click', (event) => {
+      event.preventDefault();
+      const willOpen = dropdown.hidden;
+      dropdown.hidden = !willOpen;
+      toggle.setAttribute('aria-expanded', String(willOpen));
+      if (willOpen) {
+        const active = dropdown.querySelector('.language-option.is-active');
+        if (active) {
+          active.focus();
+        }
+      }
+    });
+
+    document.addEventListener('click', (event) => {
+      if (!dropdown.contains(event.target) && !toggle.contains(event.target)) {
+        closeDropdown(dropdown, toggle);
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        closeDropdown(dropdown, toggle);
+      }
+    });
+
+    dropdown.addEventListener('click', (event) => {
+      const option = event.target.closest('[data-language-option]');
+      if (!option) {
+        return;
+      }
+      const { languageOption } = option.dataset;
+      if (!languageOption || !isSupported(languageOption)) {
+        return;
+      }
+
+      setLanguage(languageOption);
+      closeDropdown(dropdown, toggle);
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    setupDropdown();
+    const preferred = getPreferredLanguage();
+    currentLanguage = preferred;
+    updateUi(preferred);
+    persistLanguage(preferred);
+    loadGoogleTranslate();
+  });
+})();

--- a/web/public/style.css
+++ b/web/public/style.css
@@ -106,62 +106,58 @@ a {
   position: absolute;
   top: calc(100% + 10px);
   right: 0;
-  min-width: 220px;
+  min-width: 200px;
   background: rgba(15, 23, 42, 0.95);
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  border: 1px solid rgba(148, 163, 184, 0.3);
   border-radius: 14px;
-  padding: 16px;
+  padding: 12px;
   box-shadow: 0 18px 40px -24px rgba(56, 189, 248, 0.65);
   backdrop-filter: blur(12px);
   z-index: 50;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .language-switch__dropdown[hidden] {
   display: none;
 }
-
-.language-switch__widget {
-  margin-bottom: 12px;
-}
-
-.language-switch__hint {
-  margin: 0;
-  font-size: 0.75rem;
-  color: var(--text-muted);
-}
-
-.language-switch__dropdown .goog-te-gadget {
-  color: var(--text-muted);
-  font-size: 0.8rem;
-  font-family: inherit;
-}
-
-.language-switch__dropdown .goog-te-combo {
+.language-option {
   width: 100%;
-  background: rgba(30, 41, 59, 0.9);
   border: 1px solid rgba(148, 163, 184, 0.35);
   border-radius: 10px;
+  background: rgba(30, 41, 59, 0.92);
   color: var(--text);
-  padding: 8px 12px;
+  text-align: left;
+  padding: 9px 12px;
   font-size: 0.9rem;
-  appearance: none;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
 }
 
-.language-switch__dropdown .goog-te-combo:focus {
+.language-option:hover {
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
+.language-option:focus-visible {
   outline: none;
   border-color: rgba(56, 189, 248, 0.6);
   box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.25);
 }
 
-.language-switch__dropdown .goog-logo-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  margin-top: 8px;
+.language-option.is-active {
+  background: rgba(56, 189, 248, 0.15);
+  color: var(--accent);
+  border-color: rgba(56, 189, 248, 0.6);
 }
 
-.language-switch__dropdown .goog-logo-link img {
-  filter: grayscale(1) brightness(1.2);
+.language-switch__container {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
 }
 
 
@@ -683,12 +679,13 @@ a {
 }
 
 .user-identification strong {
-  font-size: 1rem;
+  font-size: 0.95rem;
+  word-break: break-word;
 }
 
 .user-identification span {
   color: var(--text-muted);
-  font-size: 0.85rem;
+  font-size: 0.8rem;
 }
 
 .user-meta {
@@ -704,7 +701,7 @@ a {
   gap: 6px;
   border-radius: 999px;
   padding: 4px 10px;
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   background: rgba(148, 163, 184, 0.16);
@@ -738,7 +735,7 @@ a {
 }
 
 .credit-count {
-  font-size: 1.3rem;
+  font-size: 1.2rem;
   font-weight: 600;
 }
 
@@ -953,6 +950,12 @@ a {
   border-radius: 18px;
   padding: 20px 28px;
   backdrop-filter: blur(14px);
+}
+
+.client-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .client-main {

--- a/web/routes/user.js
+++ b/web/routes/user.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 
 const userStore = require('../services/userStore');
-const { collectUsageStats, describeApiError } = require('../../src/util.cjs');
+const { collectUsageStats, describeApiError, queueAutomaticBackup } = require('../../src/util.cjs');
 const rep4repApi = require('../../src/api.cjs');
 const runQueue = require('../../src/runQueue.cjs');
 
@@ -51,6 +51,9 @@ function extractAuth(req) {
 router.post('/register', async (req, res) => {
   try {
     const user = await userStore.registerUser(req.body || {});
+    queueAutomaticBackup({ reason: 'novo usuário (registro)' }).catch((error) => {
+      console.warn('[API] Falha ao agendar backup automático após registro:', error.message);
+    });
     res.status(201).json({
       success: true,
       message: 'Cadastro enviado. Ative o cliente atribuindo créditos e status ativo.',

--- a/web/views/client.ejs
+++ b/web/views/client.ejs
@@ -19,7 +19,18 @@
                     <p class="brand__subtitle">Área do cliente — acompanhe créditos e rode tarefas</p>
                 </div>
             </div>
-            <button class="btn btn--ghost" type="button" data-logout hidden>Sair</button>
+            <div class="client-header__actions">
+                <div class="language-switch" data-language-switch>
+                    <button type="button" class="btn btn--ghost" data-language-toggle aria-haspopup="true" aria-expanded="false">
+                        🌐 <span data-language-label>Português</span>
+                    </button>
+                    <div class="language-switch__dropdown" data-language-dropdown hidden role="menu">
+                        <button type="button" class="language-option is-active" data-language-option="pt" role="menuitemradio" aria-checked="true">Português</button>
+                        <button type="button" class="language-option" data-language-option="en" role="menuitemradio" aria-checked="false">English</button>
+                    </div>
+                </div>
+                <button class="btn btn--ghost" type="button" data-logout hidden>Sair</button>
+            </div>
         </header>
 
         <main class="client-main">
@@ -172,6 +183,8 @@
         </main>
         <div class="toast" data-client-toast hidden></div>
     </div>
+    <div id="google_translate_container" class="language-switch__container" aria-hidden="true"></div>
+    <script src="/language.js" defer></script>
     <script src="/client.js" defer></script>
 </body>
 </html>

--- a/web/views/dashboard.ejs
+++ b/web/views/dashboard.ejs
@@ -1,7 +1,5 @@
 <% const panelBase = typeof baseUrl === 'string' && baseUrl ? baseUrl : ''; %>
 <%- include('partials/layout-start', { title: title || 'Painel', page, panelBase }) %>
-<% const basePath = typeof baseUrl !== 'undefined' ? baseUrl : ''; %>
-<%- include('partials/layout-start', { title: title || 'Painel', page, basePath }) %>
 <section class="hero">
     <div class="hero__content">
         <h1>Centro de Controle Rep4Rep</h1>
@@ -9,16 +7,14 @@
         <div class="hero__actions">
             <button class="btn btn--primary" data-command="autoRun">▶️ Executar autoRun</button>
             <button class="btn btn--secondary" data-command="backup">💾 Criar backup</button>
-            <a class="btn btn--ghost" href="<%= panelBase %>/logs">📜 Ver logs</a>
-            <a class="btn btn--ghost" href="<%= basePath %>/logs">📜 Ver logs</a>
+            <a class="btn btn--ghost" href="<%= (panelBase || '') + '/logs' %>">📜 Ver logs</a>
         </div>
         <div class="watchdog-banner" data-watchdog-state-container>
             <span class="badge badge--muted">Modo vigia</span>
             <span class="watchdog-banner__state" data-watchdog-state data-state="off">desligado</span>
             <span class="watchdog-banner__info">última execução: <strong data-watchdog-last-run>—</strong></span>
         </div>
-            <p class="hero__hint">Dica: configure o arquivo <code>accounts.txt</code>, mantenha o bot do terminal rodando com a sua key e libere créditos apenas após validar os dados do cliente.</p>
-        <p class="hero__hint">Dica: configure o arquivo <code>accounts.txt</code> e garanta que o <code>REP4REP_KEY</code> está definido antes de rodar as automações.</p>
+        <p class="hero__hint">Dica: configure o arquivo <code>accounts.txt</code>, mantenha o bot do terminal rodando com a sua key e libere créditos apenas após validar os dados do cliente.</p>
     </div>
     <aside class="hero__card">
         <h2>Resumo rápido</h2>

--- a/web/views/partials/layout-end.ejs
+++ b/web/views/partials/layout-end.ejs
@@ -3,67 +3,12 @@
             <span>&copy; <%= new Date().getFullYear() %> Rep4Rep Bot · Painel administrativo</span>
         </footer>
     </div>
-    <script>
-        (function () {
-            const toggle = document.querySelector('[data-translate-toggle]');
-            const dropdown = document.querySelector('[data-translate-container]');
-            if (!toggle || !dropdown) {
-                return;
-            }
-
-            const closeDropdown = () => {
-                dropdown.hidden = true;
-                toggle.setAttribute('aria-expanded', 'false');
-            };
-
-            toggle.addEventListener('click', (event) => {
-                event.preventDefault();
-                event.stopPropagation();
-                const willOpen = dropdown.hidden;
-                dropdown.hidden = !willOpen;
-                toggle.setAttribute('aria-expanded', String(willOpen));
-            });
-
-            document.addEventListener('click', (event) => {
-                if (!dropdown.contains(event.target) && !toggle.contains(event.target)) {
-                    closeDropdown();
-                }
-            });
-
-            document.addEventListener('keydown', (event) => {
-                if (event.key === 'Escape') {
-                    closeDropdown();
-                }
-            });
-
-            window.googleTranslateElementInit = function () {
-                if (!window.google || !window.google.translate) {
-                    return;
-                }
-                new window.google.translate.TranslateElement(
-                    {
-                        pageLanguage: 'pt',
-                        includedLanguages: 'pt,en,es,fr,it,de',
-                        layout: window.google.translate.TranslateElement.InlineLayout.SIMPLE,
-                    },
-                    'google_translate_element',
-                );
-            };
-
-            const script = document.createElement('script');
-            script.src = 'https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
-            script.defer = true;
-            document.body.appendChild(script);
-        })();
-    </script>
+    <div id="google_translate_container" class="language-switch__container" aria-hidden="true"></div>
+    <script src="/language.js" defer></script>
     <% const panelBaseHref =
-        typeof panelBase === 'string' && panelBase
-            ? panelBase
-            : typeof basePath === 'string' && basePath
-            ? basePath
-            : typeof baseUrl === 'string'
-            ? baseUrl
-            : '';
+        (typeof panelBase === 'string' && panelBase) ||
+        (typeof baseUrl === 'string' && baseUrl) ||
+        '';
     %>
     <% if (includePanelScript) { %>
         <script>

--- a/web/views/partials/layout-start.ejs
+++ b/web/views/partials/layout-start.ejs
@@ -11,15 +11,10 @@
 </head>
 <body>
     <% const baseHref =
-        typeof panelBase === 'string' && panelBase
-            ? panelBase
-            : typeof basePath === 'string' && basePath
-            ? basePath
-            : typeof baseUrl === 'string'
-            ? baseUrl
-            : '';
+        (typeof panelBase === 'string' && panelBase) ||
+        (typeof baseUrl === 'string' && baseUrl) ||
+        '';
     %>
-    <% const baseHref = typeof basePath !== 'undefined' ? basePath : (typeof baseUrl !== 'undefined' ? baseUrl : ''); %>
     <div class="app-shell">
         <header class="app-header">
             <div class="brand">
@@ -35,12 +30,12 @@
                     <a href="<%= baseHref %>/logs" class="app-nav__link <%= page === 'logs' ? 'is-active' : '' %>">Logs</a>
                 </nav>
                 <div class="language-switch" data-language-switch>
-                    <button type="button" class="btn btn--ghost" data-translate-toggle aria-haspopup="true" aria-expanded="false">
-                        🌐 <span>Idioma</span>
+                    <button type="button" class="btn btn--ghost" data-language-toggle aria-haspopup="true" aria-expanded="false">
+                        🌐 <span data-language-label>Português</span>
                     </button>
-                    <div class="language-switch__dropdown" data-translate-container hidden>
-                        <div id="google_translate_element" class="language-switch__widget"></div>
-                        <p class="language-switch__hint">Tradução automática via Google Translate.</p>
+                    <div class="language-switch__dropdown" data-language-dropdown hidden role="menu">
+                        <button type="button" class="language-option is-active" data-language-option="pt" role="menuitemradio" aria-checked="true">Português</button>
+                        <button type="button" class="language-option" data-language-option="en" role="menuitemradio" aria-checked="false">English</button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add a shared PT/EN language switcher for the admin and client interfaces with a dedicated script
- clean up the dashboard layout so it renders once and links correctly
- allow owner automations to fall back to REP4REP_KEY and trigger automatic backups whenever new users are created

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb02c3e98483259367446d9c3ab072