### PR TITLE
Improve translation UI and database durability

### DIFF
--- a/src/db.cjs
+++ b/src/db.cjs
@@ -1,12 +1,25 @@
+const fs = require('fs');
 const path = require('path');
+const { EventEmitter } = require('events');
 const sqlite3 = require('sqlite3').verbose();
 const { open } = require('sqlite');
 
-class DbWrapper {
+const ROOT_DIR = path.join(__dirname, '..');
+const DEFAULT_DB_NAME = 'steamprofiles.db';
+
+function ensureDirectory(dirPath) {
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+  }
+}
+
+class DbWrapper extends EventEmitter {
   constructor() {
+    super();
     this.db = null;
     this._initPromise = null;
-    this.databasePath = path.join(__dirname, '..', 'steamprofiles.db');
+    this.databasePath = null;
+    this._resolvedDatabaseEnv = null;
   }
 
   async init() {
@@ -16,17 +29,19 @@ class DbWrapper {
 
     if (!this._initPromise) {
       this._initPromise = (async () => {
+        const filename = this._resolveDatabasePath();
         const database = await open({
-          filename: this.databasePath,
-          driver: sqlite3.Database
+          filename,
+          driver: sqlite3.Database,
         });
 
+        await database.exec('PRAGMA journal_mode = WAL');
         this.db = database;
         await this._createProfilesTable();
         await this._createCommentsTable();
         await this._createUsersTable();
         await this._createRunQueueTable();
-        console.log("📦 Banco de dados inicializado.");
+        console.log(`📦 Banco de dados inicializado em ${this.databasePath}.`);
         return this.db;
       })().catch((err) => {
         this._initPromise = null;
@@ -35,6 +50,47 @@ class DbWrapper {
     }
 
     return this._initPromise;
+  }
+
+  _resolveDatabasePath() {
+    const envPath = (process.env.DATABASE_PATH || '').trim();
+    const previousEnv = this._resolvedDatabaseEnv;
+    const rootCandidate = path.join(ROOT_DIR, DEFAULT_DB_NAME);
+
+    let resolvedPath = null;
+
+    if (envPath) {
+      resolvedPath = path.isAbsolute(envPath)
+        ? envPath
+        : path.resolve(ROOT_DIR, envPath);
+      ensureDirectory(path.dirname(resolvedPath));
+    } else {
+      const legacyInData = path.join(ROOT_DIR, 'data', DEFAULT_DB_NAME);
+      const shouldUseLegacy = !fs.existsSync(rootCandidate) && fs.existsSync(legacyInData);
+      resolvedPath = shouldUseLegacy ? legacyInData : rootCandidate;
+      ensureDirectory(path.dirname(resolvedPath));
+    }
+
+    if (this.databasePath !== resolvedPath || previousEnv !== envPath) {
+      this.databasePath = resolvedPath;
+      this._resolvedDatabaseEnv = envPath;
+    }
+
+    return this.databasePath;
+  }
+
+  _emitChange(details = {}) {
+    const payload = {
+      timestamp: new Date().toISOString(),
+      ...details,
+    };
+
+    this.emit('change', payload);
+  }
+
+  recordChange(reason, extra = {}) {
+    const type = typeof reason === 'string' && reason.trim() ? reason.trim() : 'change';
+    this._emitChange({ type, ...extra });
   }
 
   async _ensureReady() {
@@ -150,6 +206,20 @@ class DbWrapper {
       const serializedCookies = typeof cookies === 'string'
         ? cookies
         : JSON.stringify(cookies || []);
+      let existingProfile = null;
+
+      if (steamId) {
+        existingProfile = await this.db.get(
+          `SELECT id, steamId, username FROM steamprofile WHERE steamId = ? OR username = ?`,
+          [steamId, username],
+        );
+      } else {
+        existingProfile = await this.db.get(
+          `SELECT id, steamId, username FROM steamprofile WHERE username = ?`,
+          [username],
+        );
+      }
+
       const result = await this.db.run(`
         INSERT INTO steamprofile (username, password, sharedSecret, steamId, cookies)
         VALUES (?, ?, ?, ?, ?)
@@ -161,6 +231,10 @@ class DbWrapper {
       `, [username, password, sharedSecret || null, steamId, serializedCookies]);
 
       console.log(`✅ Perfil ${username} adicionado/atualizado.`);
+      if (result?.changes > 0) {
+        const type = existingProfile ? 'profile.update' : 'profile.insert';
+        this._emitChange({ type, username, steamId: steamId || existingProfile?.steamId || null });
+      }
       return result;
     } catch (err) {
       console.error("❌ Erro ao adicionar/atualizar perfil:", err.message);
@@ -176,6 +250,7 @@ class DbWrapper {
 
     if (result.changes > 0) {
       console.log(`🗑️ Perfil '${username}' removido.`);
+      this._emitChange({ type: 'profile.remove', username });
     } else {
       console.log(`⚠️ Nenhum perfil encontrado com username '${username}'.`);
     }
@@ -224,12 +299,20 @@ class DbWrapper {
   }
 
   getDatabasePath() {
-    return this.databasePath;
+    return this.databasePath || this._resolveDatabasePath();
   }
 
   async getConnection() {
     await this._ensureReady();
     return this.db;
+  }
+
+  async close() {
+    if (this.db) {
+      await this.db.close();
+      this.db = null;
+      this._initPromise = null;
+    }
   }
 
   // Utilitário opcional para logging ou debug

--- a/src/util.cjs
+++ b/src/util.cjs
@@ -469,6 +469,18 @@ function queueAutomaticBackup({ reason = 'alteração' } = {}) {
   return scheduledBackupPromise;
 }
 
+const BACKUP_EVENT_TYPES = new Set(['profile.insert', 'profile.update', 'profile.remove']);
+if (typeof db.on === 'function') {
+  db.on('change', (event) => {
+    if (!event || !event.type || !BACKUP_EVENT_TYPES.has(event.type)) {
+      return;
+    }
+
+    const detail = event.username ? `${event.type}:${event.username}` : event.type;
+    queueAutomaticBackup({ reason: detail });
+  });
+}
+
 function removeFromAccountsFile(username) {
   if (!fs.existsSync(ACCOUNTS_PATH)) {
     return;

--- a/web/public/language.js
+++ b/web/public/language.js
@@ -57,6 +57,35 @@
     });
   }
 
+  function cleanGoogleArtifacts() {
+    const bannerFrame = document.querySelector('.goog-te-banner-frame.skiptranslate');
+    if (bannerFrame && bannerFrame.parentNode) {
+      bannerFrame.parentNode.removeChild(bannerFrame);
+    }
+
+    const skipElements = document.querySelectorAll('html.skiptranslate, body.skiptranslate');
+    skipElements.forEach((element) => {
+      element.classList.remove('skiptranslate');
+      element.style.top = '0px';
+    });
+
+    const gadgetWrappers = document.querySelectorAll('.goog-te-gadget, .goog-te-combo');
+    gadgetWrappers.forEach((element) => {
+      element.style.position = 'absolute';
+      element.style.left = '-9999px';
+      element.style.top = 'auto';
+      element.style.opacity = '0';
+      element.style.pointerEvents = 'none';
+    });
+  }
+
+  const artifactCleanupDelays = [0, 120, 400];
+  function scheduleArtifactCleanup() {
+    artifactCleanupDelays.forEach((delay) => {
+      window.setTimeout(cleanGoogleArtifacts, delay);
+    });
+  }
+
   function triggerTranslate(lang) {
     const apply = () => {
       const combo = document.querySelector('.goog-te-combo');
@@ -67,6 +96,7 @@
         combo.value = lang;
       }
       combo.dispatchEvent(new Event('change'));
+      scheduleArtifactCleanup();
       return true;
     };
 
@@ -102,16 +132,29 @@
   }
 
   function ensureHiddenContainer() {
-    const container = document.getElementById('google_translate_container');
-    if (container) {
-      container.style.position = 'absolute';
-      container.style.width = '1px';
-      container.style.height = '1px';
-      container.style.overflow = 'hidden';
-      container.style.clip = 'rect(0 0 0 0)';
-      container.style.clipPath = 'inset(50%)';
-      container.style.whiteSpace = 'nowrap';
+    let container = document.getElementById('google_translate_container');
+    if (!container) {
+      container = document.createElement('div');
+      container.id = 'google_translate_container';
+      container.className = 'language-switch__container';
+      container.setAttribute('aria-hidden', 'true');
+      document.body.appendChild(container);
     }
+
+    container.style.position = 'absolute';
+    container.style.width = '1px';
+    container.style.height = '1px';
+    container.style.overflow = 'hidden';
+    container.style.clip = 'rect(0 0 0 0)';
+    container.style.clipPath = 'inset(50%)';
+    container.style.whiteSpace = 'nowrap';
+    container.style.left = '-9999px';
+    container.style.top = 'auto';
+    container.style.right = 'auto';
+    container.style.bottom = 'auto';
+    container.style.opacity = '0';
+    container.style.pointerEvents = 'none';
+    container.style.zIndex = '-1';
   }
 
   function loadGoogleTranslate() {
@@ -137,6 +180,7 @@
       );
 
       triggerTranslate(currentLanguage);
+      scheduleArtifactCleanup();
     };
 
     const script = document.createElement('script');
@@ -144,6 +188,7 @@
     script.async = true;
     script.defer = true;
     document.head.appendChild(script);
+    scheduleArtifactCleanup();
   }
 
   function closeDropdown(dropdown, toggle) {
@@ -206,6 +251,7 @@
     currentLanguage = preferred;
     updateUi(preferred);
     persistLanguage(preferred);
+    cleanGoogleArtifacts();
     loadGoogleTranslate();
   });
 })();

--- a/web/public/style.css
+++ b/web/public/style.css
@@ -158,6 +158,13 @@ a {
   overflow: hidden;
   clip: rect(0 0 0 0);
   clip-path: inset(50%);
+  left: -9999px;
+  top: auto;
+  right: auto;
+  bottom: auto;
+  pointer-events: none;
+  opacity: 0;
+  z-index: -1;
 }
 
 
@@ -784,6 +791,35 @@ a {
   opacity: 1;
   transform: translateY(0);
   pointer-events: auto;
+}
+
+body {
+  position: static !important;
+  top: 0 !important;
+}
+
+html {
+  top: 0 !important;
+}
+
+body > .skiptranslate,
+body .skiptranslate,
+.goog-te-banner-frame.skiptranslate {
+  display: none !important;
+}
+
+.goog-te-gadget,
+.goog-te-combo {
+  position: absolute !important;
+  left: -9999px !important;
+  top: auto !important;
+  opacity: 0 !important;
+  pointer-events: none !important;
+}
+
+.goog-text-highlight {
+  background: transparent !important;
+  box-shadow: none !important;
 }
 
 .user-editor {


### PR DESCRIPTION
## Summary
- refactor the database wrapper to honour DATABASE_PATH, enable WAL, and emit change events after profile updates
- queue automatic backups whenever profile records change to persist new Steam accounts safely
- harden the language switcher by cleaning Google Translate artefacts and hiding its native widget via CSS

## Testing
- DATABASE_PATH=./tmp-test.sqlite node -e "const db=require('./src/db.cjs');db.init().then(()=>db.close()).then(()=>console.log('db ok')).catch((err)=>{console.error(err);process.exit(1);});"

------
https://chatgpt.com/codex/tasks/task_e_68cb0ef12dd08325b53592c239233aa2