### PR TITLE
Fix token resolution regression and cleanup DB profile updater

### DIFF
--- a/src/db.cjs
+++ b/src/db.cjs
@@ -228,9 +228,8 @@ class DbWrapper extends EventEmitter {
   async addOrUpdateProfile(username, password, sharedSecret, steamId, cookies) {
     await this._ensureReady();
     try {
-      const serializedCookies = typeof cookies === 'string'
-        ? cookies
-        : JSON.stringify(cookies || []);
+      const serializedCookies =
+        typeof cookies === 'string' ? cookies : JSON.stringify(cookies || []);
       let existingProfile = null;
 
       if (steamId) {
@@ -246,9 +245,6 @@ class DbWrapper extends EventEmitter {
       }
 
       let changeType = existingProfile ? 'profile.update' : 'profile.insert';
-      let dbWriteResult = null;
-      if (existingProfile) {
-        dbWriteResult = await this.db.run(
       let result = null;
 
       if (existingProfile) {
@@ -256,11 +252,17 @@ class DbWrapper extends EventEmitter {
           `UPDATE steamprofile
              SET username = ?, password = ?, sharedSecret = ?, steamId = ?, cookies = ?
            WHERE id = ?`,
-          [username, password, sharedSecret || null, steamId, serializedCookies, existingProfile.id],
+          [
+            username,
+            password,
+            sharedSecret || null,
+            steamId,
+            serializedCookies,
+            existingProfile.id,
+          ],
         );
       } else {
         try {
-          dbWriteResult = await this.db.run(
           result = await this.db.run(
             `INSERT INTO steamprofile (username, password, sharedSecret, steamId, cookies)
              VALUES (?, ?, ?, ?, ?)`,
@@ -278,7 +280,6 @@ class DbWrapper extends EventEmitter {
             if (conflicting) {
               existingProfile = conflicting;
               changeType = 'profile.update';
-              dbWriteResult = await this.db.run(
               result = await this.db.run(
                 `UPDATE steamprofile
                    SET username = ?, password = ?, sharedSecret = ?, steamId = ?, cookies = ?
@@ -302,44 +303,12 @@ class DbWrapper extends EventEmitter {
       }
 
       console.log(`✅ Perfil ${username} adicionado/atualizado.`);
-      if (dbWriteResult?.changes > 0) {
-        const steamRef = steamId || existingProfile?.steamId || null;
-        this._emitChange({ type: changeType, username, steamId: steamRef });
-      }
-
-      await this.checkpoint('PASSIVE');
-      return dbWriteResult;
-
-      console.log(`✅ Perfil ${username} adicionado/atualizado.`);
       if (result?.changes > 0) {
         const steamRef = steamId || existingProfile?.steamId || null;
         this._emitChange({ type: changeType, username, steamId: steamRef });
       }
 
       await this.checkpoint('PASSIVE');
-
-      console.log(`✅ Perfil ${username} adicionado/atualizado.`);
-      if (result?.changes > 0) {
-        const steamRef = steamId || existingProfile?.steamId || null;
-        this._emitChange({ type: changeType, username, steamId: steamRef });
-      }
-
-      await this.checkpoint('PASSIVE');
-      const result = await this.db.run(`
-        INSERT INTO steamprofile (username, password, sharedSecret, steamId, cookies)
-        VALUES (?, ?, ?, ?, ?)
-        ON CONFLICT(steamId) DO UPDATE SET
-          username = excluded.username,
-          password = excluded.password,
-          sharedSecret = excluded.sharedSecret,
-          cookies = excluded.cookies
-      `, [username, password, sharedSecret || null, steamId, serializedCookies]);
-
-      console.log(`✅ Perfil ${username} adicionado/atualizado.`);
-      if (result?.changes > 0) {
-        const type = existingProfile ? 'profile.update' : 'profile.insert';
-        this._emitChange({ type, username, steamId: steamId || existingProfile?.steamId || null });
-      }
       return result;
     } catch (err) {
       console.error("❌ Erro ao adicionar/atualizar perfil:", err.message);

--- a/src/util.cjs
+++ b/src/util.cjs
@@ -55,16 +55,18 @@ function getEnvRep4RepKey() {
 
 function resolveApiToken(token, { fallbackToEnv = true } = {}) {
   if (token === false) {
-  if (token === '' || token === false) {
     return null;
   }
+
   const direct = normalizeApiToken(token);
   if (direct) {
     return direct;
   }
+
   if (!fallbackToEnv) {
     return null;
   }
+
   const envToken = normalizeApiToken(process.env.REP4REP_KEY);
   return envToken || null;
 }
@@ -1368,19 +1370,8 @@ async function prioritizedAutoRun(options = {}) {
       );
     }
 
-    const jobApiToken = resolveClientApiToken(client);
-    if (!jobApiToken) {
-    const allowEnvFallback = client?.role && client.role !== 'customer';
-    const jobApiToken = resolveApiToken(client.rep4repKey, {
-      fallbackToEnv: Boolean(allowEnvFallback),
-    });
-    if (!jobApiToken) {
-    const clientToken = resolveApiToken(client.rep4repKey, {
-      fallbackToEnv: client.role === 'admin',
-    });
-
-    const clientToken = resolveApiToken(client.rep4repKey, { fallbackToEnv: false });
-    if (!clientToken) {
+    const apiToken = resolveClientApiToken(client);
+    if (!apiToken) {
       return failQueuedJob(
         job,
         client,
@@ -1432,8 +1423,7 @@ async function prioritizedAutoRun(options = {}) {
     try {
       const summary = await autoRun({
         ...baseRunOptions,
-        apiToken: jobApiToken,
-        apiToken: clientToken,
+        apiToken,
         maxCommentsPerAccount: jobMaxComments,
         accountLimit: jobAccountLimit,
         onTaskComplete,
@@ -1462,8 +1452,7 @@ async function prioritizedAutoRun(options = {}) {
       }
 
       const cleanup = await removeRemoteProfiles(summary, {
-        apiToken: jobApiToken,
-        apiToken: clientToken,
+        apiToken,
         apiClient: baseRunOptions.apiClient || api,
       });
 


### PR DESCRIPTION
## Summary
- fix resolveApiToken to handle false tokens correctly and use consistent API token resolution in the queue processor
- simplify addOrUpdateProfile by removing duplicated logic and ensuring updates emit change events once

## Testing
- node --check src/util.cjs
- node --check src/db.cjs

------
https://chatgpt.com/codex/tasks/task_e_68cb2fa19b4c832587e2e7e98bc3b542